### PR TITLE
feat: add VMDR scan scheduling and policy tools (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   QUALYS_USERNAME: ${{ secrets.QUALYS_USERNAME }}
   QUALYS_PASSWORD: ${{ secrets.QUALYS_PASSWORD }}
@@ -175,11 +179,29 @@ jobs:
       - name: Install dependencies
         run: pip install -e . 2>/dev/null || pip install mcp httpx
 
-      - name: Run eval harness
-        run: python eval.py --quick --limit 50 --json eval_results.json
+      - name: Run eval (if available)
+        id: eval
+        run: |
+          if [ -f eval.py ]; then
+            python eval.py --quick --limit 50 --json eval_results.json
+            echo "eval_ran=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "eval.py not found, skipping"
+            echo "eval_ran=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check eval threshold
+        if: steps.eval.outputs.eval_ran == 'true'
+        run: |
+          score=$(python -c "import json; d=json.load(open('eval_results.json')); print(d.get('score', d.get('accuracy', 0)))")
+          echo "Eval score: ${score}%"
+          if (( $(echo "$score < $EVAL_PASS_THRESHOLD" | bc -l) )); then
+            echo "::error::Eval score ${score}% is below threshold ${EVAL_PASS_THRESHOLD}%"
+            exit 1
+          fi
 
       - name: Upload eval results
-        if: always()
+        if: always() && steps.eval.outputs.eval_ran == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: eval-results
@@ -208,7 +230,7 @@ jobs:
   pr-comment:
     name: PR Summary Comment
     runs-on: ubuntu-latest
-    needs: [benchmark, eval, conversation-tests]
+    needs: [smoke-test, benchmark, eval, conversation-tests]
     if: always() && github.event_name == 'pull_request'
     permissions:
       pull-requests: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,7 @@ env:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   full-eval:
@@ -52,48 +53,57 @@ jobs:
 
       - name: Run full eval
         if: steps.creds.outputs.skip != 'true'
-        run: python eval.py --limit 500 --json eval_results.json
+        run: |
+          if [ -f eval.py ]; then
+            python eval.py --limit 500 --json eval_results.json
+          else
+            echo "eval.py not found, skipping"
+          fi
 
-      - name: Post eval summary
+      - name: Run full benchmark
+        if: steps.creds.outputs.skip != 'true'
+        run: python benchmark.py --json benchmark_results.json
+
+      - name: Run conversation tests
+        if: steps.creds.outputs.skip != 'true'
+        run: python tests/run_conversations.py --verbose
+
+      - name: Post summary
         if: always()
         run: |
-          python3 << 'PYEOF'
-          import json, os
+          echo "## Nightly Eval Results — $(date -u +%Y-%m-%d)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          try:
-              with open("eval_results.json") as f:
-                  data = json.load(f)
-          except FileNotFoundError:
-              print("No eval results found")
-              exit(0)
+          if [ -f benchmark_results.json ]; then
+            echo "### Benchmark" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            python -c "
+          import json
+          d = json.load(open('benchmark_results.json'))
+          for r in d['results']:
+              print(f\"{r['tool']:40s}  cold={r['cold_s']:.2f}s  warm={r['warm_s']:.2f}s\")
+          " >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
 
-          icon = "✅" if data["score_pct"] >= data["threshold"] else "❌"
+          if [ -f eval_results.json ]; then
+            echo "### Eval" >> "$GITHUB_STEP_SUMMARY"
+            score=$(python -c "import json; d=json.load(open('eval_results.json')); print(d.get('score', d.get('accuracy', 'N/A')))")
+            echo "Score: **${score}%**" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### Eval" >> "$GITHUB_STEP_SUMMARY"
+            echo "_eval.py not available — skipped_" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
-          summary = f"""## {icon} Nightly Eval Results
-
-          | Metric | Value |
-          |--------|-------|
-          | Score | {data['score_pct']}% |
-          | Threshold | {data['threshold']}% |
-          | Passed | {data['passed']} |
-          | Failed | {data['failed']} |
-          | Errors | {data['errors']} |
-          | Skipped | {data['skipped']} |
-          | Total | {data['total']} |
-          """
-
-          with open(os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null"), "a") as f:
-              f.write(summary)
-
-          print(summary)
-          PYEOF
-
-      - name: Upload eval results
+      - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-eval-results
-          path: eval_results.json
+          name: nightly-results-${{ github.run_number }}
+          path: |
+            benchmark_results.json
+            eval_results.json
+          retention-days: 90
 
   update-baseline:
     name: Update Benchmark Baseline

--- a/internal/modules/vmdr/client.go
+++ b/internal/modules/vmdr/client.go
@@ -1,0 +1,808 @@
+package vmdr
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nelssec/qualys-mcp/internal/common"
+)
+
+type Client struct {
+	http    *common.HTTPClient
+	baseURL string
+}
+
+func NewClient(http *common.HTTPClient, baseURL string) *Client {
+	return &Client{
+		http:    http,
+		baseURL: baseURL,
+	}
+}
+
+type Host struct {
+	ID            string `xml:"ID" json:"id"`
+	IP            string `xml:"IP" json:"ip"`
+	Hostname      string `xml:"DNS" json:"hostname,omitempty"`
+	NetbiosName   string `xml:"NETBIOS" json:"netbios,omitempty"`
+	OS            string `xml:"OS" json:"os,omitempty"`
+	LastScan      string `xml:"LAST_VULN_SCAN_DATETIME" json:"lastScan,omitempty"`
+	TrackingMethod string `xml:"TRACKING_METHOD" json:"trackingMethod,omitempty"`
+}
+
+type Detection struct {
+	QID        int    `xml:"QID" json:"qid"`
+	Type       string `xml:"TYPE" json:"type,omitempty"`
+	Severity   int    `xml:"SEVERITY" json:"severity"`
+	Port       int    `xml:"PORT" json:"port,omitempty"`
+	Protocol   string `xml:"PROTOCOL" json:"protocol,omitempty"`
+	SSL        int    `xml:"SSL" json:"ssl,omitempty"`
+	Status     string `xml:"STATUS" json:"status"`
+	FirstFound string `xml:"FIRST_FOUND_DATETIME" json:"firstFound,omitempty"`
+	LastFound  string `xml:"LAST_FOUND_DATETIME" json:"lastFound,omitempty"`
+	Results    string `xml:"RESULTS" json:"results,omitempty"`
+	QDS        int    `xml:"QDS>SEVERITY" json:"qds,omitempty"`
+	QDSFactors string `xml:"QDS_FACTORS" json:"qdsFactors,omitempty"`
+}
+
+type HostDetection struct {
+	Host       Host        `xml:"HOST" json:"host"`
+	Detections []Detection `xml:"DETECTION_LIST>DETECTION" json:"detections"`
+}
+
+type Scan struct {
+	Ref        string `xml:"REF" json:"ref"`
+	Title      string `xml:"TITLE" json:"title"`
+	Type       string `xml:"TYPE" json:"type"`
+	Status     string `xml:"STATUS>STATE" json:"status"`
+	LaunchDate string `xml:"LAUNCH_DATETIME" json:"launchDate"`
+	Duration   string `xml:"DURATION" json:"duration,omitempty"`
+	Target     string `xml:"TARGET" json:"target,omitempty"`
+}
+
+type AssetGroup struct {
+	ID    string `xml:"ID" json:"id"`
+	Title string `xml:"TITLE" json:"title"`
+}
+
+type ScanSchedule struct {
+	ID             string `xml:"ID" json:"id"`
+	Title          string `xml:"TITLE" json:"title"`
+	Active         string `xml:"ACTIVE" json:"active"`
+	OptionProfile  string `xml:"OPTION_PROFILE>TITLE" json:"optionProfile,omitempty"`
+	Target         string `xml:"TARGET" json:"target,omitempty"`
+	NextLaunchDate string `xml:"NEXTLAUNCH_DATE" json:"nextLaunchDate,omitempty"`
+	Schedule       string `xml:"SCHEDULE" json:"schedule,omitempty"`
+}
+
+type OptionProfile struct {
+	ID          string `xml:"ID" json:"id"`
+	Title       string `xml:"TITLE" json:"title"`
+	IsDefault   string `xml:"IS_DEFAULT" json:"isDefault,omitempty"`
+	IsGlobal    string `xml:"IS_GLOBAL" json:"isGlobal,omitempty"`
+	OwnerName   string `xml:"OWNER>NAME" json:"ownerName,omitempty"`
+	UpdateDate  string `xml:"UPDATE_DATE" json:"updateDate,omitempty"`
+}
+
+type IPEntry struct {
+	IP    string `xml:"IP" json:"ip,omitempty"`
+	Range string `xml:"RANGE" json:"range,omitempty"`
+}
+
+type ScanLaunchResponse struct {
+	XMLName  xml.Name `xml:"SIMPLE_RETURN"`
+	Response struct {
+		ItemList []struct {
+			Key   string `xml:"KEY"`
+			Value string `xml:"VALUE"`
+		} `xml:"ITEM_LIST>ITEM"`
+		Text string `xml:"TEXT"`
+		Code string `xml:"CODE"`
+	} `xml:"RESPONSE"`
+}
+
+type ScanStatus struct {
+	Ref            string `json:"ref"`
+	Title          string `json:"title"`
+	Status         string `json:"status"`
+	Target         string `json:"target,omitempty"`
+	LaunchDate     string `json:"launchDate,omitempty"`
+	Duration       string `json:"duration,omitempty"`
+	Type           string `json:"type,omitempty"`
+	OptionProfile  string `json:"optionProfile,omitempty"`
+	Processed      int    `json:"processed,omitempty"`
+	TotalHosts     int    `json:"totalHosts,omitempty"`
+	ProgressPct    int    `json:"progressPercent,omitempty"`
+	EstCompletionTime string `json:"estimatedCompletion,omitempty"`
+}
+
+type CoverageGap struct {
+	ID       string `json:"id"`
+	IP       string `json:"ip"`
+	Hostname string `json:"hostname,omitempty"`
+	OS       string `json:"os,omitempty"`
+	LastScan string `json:"lastScan"`
+	DaysAgo  int    `json:"daysSinceLastScan"`
+}
+
+type DetectionStats struct {
+	TotalDetections int         `json:"totalDetections"`
+	UniqueHosts     int         `json:"uniqueHosts"`
+	UniqueQIDs      int         `json:"uniqueQids"`
+	BySeverity      map[int]int `json:"bySeverity"`
+	TopQIDs         []QIDCount  `json:"topQids"`
+	AvgQDS          int         `json:"avgQdsScore"`
+	MaxQDS          int         `json:"maxQdsScore"`
+}
+
+type QIDCount struct {
+	QID      int `json:"qid"`
+	Count    int `json:"count"`
+	Severity int `json:"severity"`
+}
+
+type DetectionSummary struct {
+	Stats        DetectionStats   `json:"stats"`
+	TopRiskHosts []HostSummary    `json:"topRiskHosts"`
+	TopFindings  []DetectionBrief `json:"topFindings"`
+}
+
+type HostSummary struct {
+	HostID         string `json:"hostId"`
+	IP             string `json:"ip"`
+	DetectionCount int    `json:"detectionCount"`
+	MaxSeverity    int    `json:"maxSeverity"`
+}
+
+type DetectionBrief struct {
+	QID       int    `json:"qid"`
+	Severity  int    `json:"severity"`
+	Status    string `json:"status"`
+	HostCount int    `json:"hostCount"`
+}
+
+type HostListResponse struct {
+	XMLName  xml.Name `xml:"HOST_LIST_OUTPUT"`
+	Response struct {
+		HostList []Host `xml:"HOST_LIST>HOST"`
+	} `xml:"RESPONSE"`
+}
+
+type HostDetectionResponse struct {
+	XMLName  xml.Name `xml:"HOST_LIST_VM_DETECTION_OUTPUT"`
+	Response struct {
+		HostList []HostDetection `xml:"HOST_LIST>HOST"`
+	} `xml:"RESPONSE"`
+}
+
+type ScanListResponse struct {
+	XMLName  xml.Name `xml:"SCAN_LIST_OUTPUT"`
+	Response struct {
+		ScanList []Scan `xml:"SCAN_LIST>SCAN"`
+	} `xml:"RESPONSE"`
+}
+
+type AssetGroupListResponse struct {
+	XMLName  xml.Name `xml:"ASSET_GROUP_LIST_OUTPUT"`
+	Response struct {
+		AssetGroupList []AssetGroup `xml:"ASSET_GROUP_LIST>ASSET_GROUP"`
+	} `xml:"RESPONSE"`
+}
+
+type ScanScheduleListResponse struct {
+	XMLName  xml.Name `xml:"SCHEDULE_SCAN_LIST_OUTPUT"`
+	Response struct {
+		ScanList []ScanSchedule `xml:"SCAN_LIST>SCAN"`
+	} `xml:"RESPONSE"`
+}
+
+type OptionProfileListResponse struct {
+	XMLName  xml.Name `xml:"OPTION_PROFILES"`
+	Response struct {
+		ProfileList []OptionProfile `xml:"OPTION_PROFILE"`
+	} `xml:""`
+}
+
+type IPListResponse struct {
+	XMLName  xml.Name `xml:"IP_LIST_OUTPUT"`
+	Response struct {
+		IPSet []IPEntry `xml:"RESPONSE>IP_SET>IP,omitempty"`
+		IPRangeSet []IPEntry `xml:"RESPONSE>IP_SET>IP_RANGE,omitempty"`
+	} `xml:""`
+}
+
+func (c *Client) ListHosts(ctx context.Context, filter string, limit int) ([]Host, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/asset/host/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "list")
+	params.Set("details", "All")
+	if filter != "" {
+		params.Set("ids", filter)
+	}
+	if limit > 0 {
+		params.Set("truncation_limit", fmt.Sprintf("%d", limit))
+	}
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp HostListResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return resp.Response.HostList, nil
+}
+
+func (c *Client) GetHostDetections(ctx context.Context, hostID string, severityFilter int, qdsMin int) ([]Detection, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/asset/host/vm/detection/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "list")
+	params.Set("ids", hostID)
+	params.Set("show_igs", "1")
+	params.Set("show_qds", "1")
+	params.Set("filter_superseded_qids", "1")
+	if severityFilter > 0 {
+		params.Set("severities", fmt.Sprintf("%d", severityFilter))
+	}
+	if qdsMin > 0 {
+		params.Set("qds_min", fmt.Sprintf("%d", qdsMin))
+	}
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp HostDetectionResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	if len(resp.Response.HostList) == 0 {
+		return nil, nil
+	}
+
+	return resp.Response.HostList[0].Detections, nil
+}
+
+func (c *Client) SearchDetections(ctx context.Context, qids string, severity int, qdsMin int, limit int) ([]HostDetection, error) {
+	return c.SearchDetectionsWithStatus(ctx, qids, severity, qdsMin, limit, "")
+}
+
+func (c *Client) SearchDetectionsWithStatus(ctx context.Context, qids string, severity int, qdsMin int, limit int, status string) ([]HostDetection, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/asset/host/vm/detection/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "list")
+	params.Set("show_qds", "1")
+	params.Set("filter_superseded_qids", "1")
+	if qids != "" {
+		params.Set("qids", qids)
+	}
+	if severity > 0 {
+		params.Set("severities", fmt.Sprintf("%d", severity))
+	}
+	if qdsMin > 0 {
+		params.Set("qds_min", fmt.Sprintf("%d", qdsMin))
+	}
+	if limit > 0 {
+		params.Set("truncation_limit", fmt.Sprintf("%d", limit))
+	}
+	if status != "" {
+		params.Set("status", status)
+	}
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp HostDetectionResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return resp.Response.HostList, nil
+}
+
+func (c *Client) ListScans(ctx context.Context, status string, limit int) ([]Scan, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/scan/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "list")
+	if status != "" {
+		params.Set("state", status)
+	}
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ScanListResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	if limit > 0 && len(resp.Response.ScanList) > limit {
+		return resp.Response.ScanList[:limit], nil
+	}
+
+	return resp.Response.ScanList, nil
+}
+
+type ScanResultJSON struct {
+	ScanReportTemplateTitle string `json:"scan_report_template_title,omitempty"`
+	ResultDate              string `json:"result_date,omitempty"`
+	Company                 string `json:"company,omitempty"`
+	Username                string `json:"username,omitempty"`
+	LaunchDate              string `json:"launch_date,omitempty"`
+	ActiveHosts             string `json:"active_hosts,omitempty"`
+	TotalHosts              string `json:"total_hosts,omitempty"`
+	Type                    string `json:"type,omitempty"`
+	ScanType                string `json:"scan_type,omitempty"`
+	Status                  string `json:"status,omitempty"`
+	Reference               string `json:"reference,omitempty"`
+	Duration                string `json:"duration,omitempty"`
+	ScanTitle               string `json:"scan_title,omitempty"`
+	OptionProfile           string `json:"option_profile,omitempty"`
+	FQDN                    string `json:"fqdn,omitempty"`
+	IP                      string `json:"ip,omitempty"`
+	DNS                     string `json:"dns,omitempty"`
+	QID                     string `json:"qid,omitempty"`
+	Title                   string `json:"title,omitempty"`
+	Severity                string `json:"severity,omitempty"`
+	Port                    string `json:"port,omitempty"`
+	Protocol                string `json:"protocol,omitempty"`
+	Results                 string `json:"results,omitempty"`
+}
+
+func (c *Client) GetScanResults(ctx context.Context, scanRef string) ([]ScanResultJSON, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/scan/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "fetch")
+	params.Set("scan_ref", scanRef)
+	params.Set("output_format", "json_extended")
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data) == 0 {
+		return []ScanResultJSON{}, nil
+	}
+
+	var results []ScanResultJSON
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return results, nil
+}
+
+func (c *Client) ListAssetGroups(ctx context.Context) ([]AssetGroup, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/asset/group/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "list")
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp AssetGroupListResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return resp.Response.AssetGroupList, nil
+}
+
+func (c *Client) GetDetectionStats(ctx context.Context, qids string, severity int, qdsMin int, status string, limit int) (*DetectionStats, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	detections, err := c.SearchDetectionsWithStatus(ctx, qids, severity, qdsMin, limit, status)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &DetectionStats{
+		BySeverity: make(map[int]int),
+		TopQIDs:    []QIDCount{},
+	}
+
+	hostSet := make(map[string]bool)
+	qidCounts := make(map[int]*QIDCount)
+	var totalQDS, qdsCount int
+
+	for _, host := range detections {
+		hostID := host.Host.ID
+		if hostID == "" {
+			hostID = host.Host.IP
+		}
+		if hostID != "" {
+			hostSet[hostID] = true
+		}
+
+		for _, det := range host.Detections {
+			stats.TotalDetections++
+			stats.BySeverity[det.Severity]++
+
+			if _, exists := qidCounts[det.QID]; !exists {
+				qidCounts[det.QID] = &QIDCount{
+					QID:      det.QID,
+					Count:    0,
+					Severity: det.Severity,
+				}
+			}
+			qidCounts[det.QID].Count++
+
+			if det.QDS > 0 {
+				totalQDS += det.QDS
+				qdsCount++
+				if det.QDS > stats.MaxQDS {
+					stats.MaxQDS = det.QDS
+				}
+			}
+		}
+	}
+
+	stats.UniqueHosts = len(hostSet)
+	stats.UniqueQIDs = len(qidCounts)
+
+	if qdsCount > 0 {
+		stats.AvgQDS = totalQDS / qdsCount
+	}
+
+	var sortable []QIDCount
+	for _, qc := range qidCounts {
+		sortable = append(sortable, QIDCount{qc.QID, qc.Count, qc.Severity})
+	}
+	sort.Slice(sortable, func(i, j int) bool {
+		return sortable[i].Count > sortable[j].Count
+	})
+	for i := 0; i < len(sortable) && i < 10; i++ {
+		stats.TopQIDs = append(stats.TopQIDs, sortable[i])
+	}
+
+	return stats, nil
+}
+
+func (c *Client) GetDetectionSummary(ctx context.Context, qids string, severity int, qdsMin int, status string, limit int) (*DetectionSummary, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	detections, err := c.SearchDetectionsWithStatus(ctx, qids, severity, qdsMin, limit, status)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &DetectionSummary{
+		Stats: DetectionStats{
+			BySeverity: make(map[int]int),
+			TopQIDs:    []QIDCount{},
+		},
+		TopRiskHosts: []HostSummary{},
+		TopFindings:  []DetectionBrief{},
+	}
+
+	hostMap := make(map[string]*HostSummary)
+	qidCounts := make(map[int]*QIDCount)
+	qidHostCounts := make(map[int]int)
+	var totalQDS, qdsCount int
+
+	for _, host := range detections {
+		hostID := host.Host.ID
+		if hostID == "" {
+			hostID = host.Host.IP
+		}
+
+		if _, exists := hostMap[hostID]; !exists {
+			hostMap[hostID] = &HostSummary{
+				HostID:      hostID,
+				IP:          host.Host.IP,
+				MaxSeverity: 0,
+			}
+		}
+
+		for _, det := range host.Detections {
+			summary.Stats.TotalDetections++
+			summary.Stats.BySeverity[det.Severity]++
+			hostMap[hostID].DetectionCount++
+
+			if det.Severity > hostMap[hostID].MaxSeverity {
+				hostMap[hostID].MaxSeverity = det.Severity
+			}
+
+			if _, exists := qidCounts[det.QID]; !exists {
+				qidCounts[det.QID] = &QIDCount{
+					QID:      det.QID,
+					Count:    0,
+					Severity: det.Severity,
+				}
+			}
+			qidCounts[det.QID].Count++
+			qidHostCounts[det.QID]++
+
+			if det.QDS > 0 {
+				totalQDS += det.QDS
+				qdsCount++
+				if det.QDS > summary.Stats.MaxQDS {
+					summary.Stats.MaxQDS = det.QDS
+				}
+			}
+		}
+	}
+
+	summary.Stats.UniqueHosts = len(hostMap)
+	summary.Stats.UniqueQIDs = len(qidCounts)
+	if qdsCount > 0 {
+		summary.Stats.AvgQDS = totalQDS / qdsCount
+	}
+
+	var sortableHosts []*HostSummary
+	for _, h := range hostMap {
+		sortableHosts = append(sortableHosts, h)
+	}
+	sort.Slice(sortableHosts, func(i, j int) bool {
+		if sortableHosts[i].MaxSeverity != sortableHosts[j].MaxSeverity {
+			return sortableHosts[i].MaxSeverity > sortableHosts[j].MaxSeverity
+		}
+		return sortableHosts[i].DetectionCount > sortableHosts[j].DetectionCount
+	})
+	for i := 0; i < len(sortableHosts) && i < 10; i++ {
+		summary.TopRiskHosts = append(summary.TopRiskHosts, *sortableHosts[i])
+	}
+
+	type qidSort struct {
+		qid       int
+		count     int
+		sev       int
+		hostCount int
+	}
+	var sortableQIDs []qidSort
+	for qid, qc := range qidCounts {
+		sortableQIDs = append(sortableQIDs, qidSort{qid, qc.Count, qc.Severity, qidHostCounts[qid]})
+	}
+	sort.Slice(sortableQIDs, func(i, j int) bool {
+		if sortableQIDs[i].sev != sortableQIDs[j].sev {
+			return sortableQIDs[i].sev > sortableQIDs[j].sev
+		}
+		return sortableQIDs[i].hostCount > sortableQIDs[j].hostCount
+	})
+	for i := 0; i < len(sortableQIDs) && i < 10; i++ {
+		summary.Stats.TopQIDs = append(summary.Stats.TopQIDs, QIDCount{
+			QID: sortableQIDs[i].qid, Count: sortableQIDs[i].count, Severity: sortableQIDs[i].sev,
+		})
+	}
+	for i := 0; i < len(sortableQIDs) && i < 20; i++ {
+		summary.TopFindings = append(summary.TopFindings, DetectionBrief{
+			QID: sortableQIDs[i].qid, Severity: sortableQIDs[i].sev, HostCount: sortableQIDs[i].hostCount,
+		})
+	}
+
+	return summary, nil
+}
+
+func (c *Client) GetScanSchedules(ctx context.Context) ([]ScanSchedule, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/schedule/scan/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "list")
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ScanScheduleListResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return resp.Response.ScanList, nil
+}
+
+func (c *Client) GetOptionProfiles(ctx context.Context) ([]OptionProfile, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/subscription/option_profile/vm/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "list")
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp OptionProfileListResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return resp.Response.ProfileList, nil
+}
+
+func (c *Client) GetIPList(ctx context.Context) ([]IPEntry, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/asset/ip/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "list")
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp IPListResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	var result []IPEntry
+	for _, ip := range resp.Response.IPSet {
+		result = append(result, IPEntry{IP: ip.IP})
+	}
+	for _, r := range resp.Response.IPRangeSet {
+		result = append(result, IPEntry{Range: r.Range})
+	}
+
+	return result, nil
+}
+
+func (c *Client) LaunchScan(ctx context.Context, title string, optionProfile string, targets string) (map[string]string, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/scan/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "launch")
+	params.Set("scan_title", title)
+	params.Set("option_title", optionProfile)
+	params.Set("ip", targets)
+
+	body := strings.NewReader(params.Encode())
+	data, err := c.http.Post(ctx, endpoint, body, "application/x-www-form-urlencoded")
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ScanLaunchResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	result := map[string]string{
+		"text": resp.Response.Text,
+		"code": resp.Response.Code,
+	}
+	for _, item := range resp.Response.ItemList {
+		result[item.Key] = item.Value
+	}
+
+	return result, nil
+}
+
+func (c *Client) GetScanStatus(ctx context.Context, scanRef string) (*ScanStatus, error) {
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/scan/", c.baseURL)
+
+	params := url.Values{}
+	params.Set("action", "list")
+	params.Set("scan_ref", scanRef)
+	params.Set("show_status", "1")
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ScanListResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	if len(resp.Response.ScanList) == 0 {
+		return nil, fmt.Errorf("scan not found: %s", scanRef)
+	}
+
+	scan := resp.Response.ScanList[0]
+	status := &ScanStatus{
+		Ref:        scan.Ref,
+		Title:      scan.Title,
+		Status:     scan.Status,
+		Target:     scan.Target,
+		LaunchDate: scan.LaunchDate,
+		Duration:   scan.Duration,
+		Type:       scan.Type,
+	}
+
+	// Fetch detailed results for progress info if scan is running
+	if scan.Status == "Running" {
+		results, err := c.GetScanResults(ctx, scanRef)
+		if err == nil && len(results) > 0 {
+			total := 0
+			processed := 0
+			for _, r := range results {
+				if r.TotalHosts != "" {
+					fmt.Sscanf(r.TotalHosts, "%d", &total)
+				}
+				if r.ActiveHosts != "" {
+					fmt.Sscanf(r.ActiveHosts, "%d", &processed)
+				}
+			}
+			if total > 0 {
+				status.TotalHosts = total
+				status.Processed = processed
+				status.ProgressPct = (processed * 100) / total
+			}
+		}
+	}
+
+	return status, nil
+}
+
+func (c *Client) GetCoverageGaps(ctx context.Context, daysThreshold int, limit int) ([]CoverageGap, error) {
+	if daysThreshold <= 0 {
+		daysThreshold = 7
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+
+	hosts, err := c.ListHosts(ctx, "", limit)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	threshold := now.AddDate(0, 0, -daysThreshold)
+
+	var gaps []CoverageGap
+	for _, host := range hosts {
+		if host.LastScan == "" {
+			gaps = append(gaps, CoverageGap{
+				ID:       host.ID,
+				IP:       host.IP,
+				Hostname: host.Hostname,
+				OS:       host.OS,
+				LastScan: "never",
+				DaysAgo:  -1,
+			})
+			continue
+		}
+
+		lastScan, err := time.Parse("2006-01-02T15:04:05Z", host.LastScan)
+		if err != nil {
+			continue
+		}
+
+		if lastScan.Before(threshold) {
+			daysAgo := int(now.Sub(lastScan).Hours() / 24)
+			gaps = append(gaps, CoverageGap{
+				ID:       host.ID,
+				IP:       host.IP,
+				Hostname: host.Hostname,
+				OS:       host.OS,
+				LastScan: host.LastScan,
+				DaysAgo:  daysAgo,
+			})
+		}
+	}
+
+	sort.Slice(gaps, func(i, j int) bool {
+		return gaps[i].DaysAgo > gaps[j].DaysAgo
+	})
+
+	return gaps, nil
+}

--- a/internal/modules/vmdr/tools.go
+++ b/internal/modules/vmdr/tools.go
@@ -1,0 +1,465 @@
+package vmdr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nelssec/qualys-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+var newToolResultError = common.NewToolResultError
+
+type Module struct {
+	client *Client
+}
+
+func New(http *common.HTTPClient, baseURL string) *Module {
+	return &Module{
+		client: NewClient(http, baseURL),
+	}
+}
+
+func NewWithClient(client *Client) *Module {
+	return &Module{
+		client: client,
+	}
+}
+
+func (m *Module) RegisterTools(s *server.MCPServer) {
+	s.AddTool(
+		mcp.NewTool("vmdr_list_hosts",
+			mcp.WithDescription("List hosts from VMDR with vulnerability counts. Use to get an overview of hosts and their security posture."),
+			mcp.WithString("filter", mcp.Description("Optional filter by host ID or IP range")),
+			mcp.WithNumber("limit", mcp.Description("Maximum number of hosts to return (default 100)")),
+		),
+		m.listHosts,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_get_host_detections",
+			mcp.WithDescription("Get vulnerability detections for a specific host. Returns detailed vulnerability information including QIDs, CVEs, severity, and QDS scores."),
+			mcp.WithString("host_id", mcp.Required(), mcp.Description("The host ID to get detections for")),
+			mcp.WithNumber("severity", mcp.Description("Filter by minimum severity (1-5, where 5 is critical)")),
+			mcp.WithNumber("qds_min", mcp.Description("Filter by minimum QDS (Qualys Detection Score) from 1-100")),
+		),
+		m.getHostDetections,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_search_detections",
+			mcp.WithDescription("Search detections across hosts. For overview, use vmdr_get_detection_summary instead. Auto-selects output mode: QID=full, severity filter=brief, no filters=stats."),
+			mcp.WithString("qids", mcp.Description("QID or comma-separated list of QIDs to search for")),
+			mcp.WithNumber("severity", mcp.Description("Minimum severity (1-5). Recommended: 5 for critical only")),
+			mcp.WithNumber("qds_min", mcp.Description("Minimum QDS (1-100). Recommended: 90+ for high risk")),
+			mcp.WithNumber("limit", mcp.Description("Maximum results (default 50)")),
+			mcp.WithString("status", mcp.Description("Filter by status: Active, Fixed, New")),
+			mcp.WithString("output_mode", mcp.Description("Override: 'full', 'brief', 'stats'")),
+		),
+		m.searchDetections,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_get_detection_stats",
+			mcp.WithDescription("FAST: Get aggregated detection statistics. Returns counts by severity, top QIDs, and QDS metrics. Use this first for overview queries. Always filter by severity:5 for critical-only."),
+			mcp.WithString("qids", mcp.Description("QID or comma-separated list of QIDs to filter")),
+			mcp.WithNumber("severity", mcp.Description("Filter by minimum severity (1-5, where 5 is critical). Recommended: 5")),
+			mcp.WithNumber("qds_min", mcp.Description("Filter by minimum QDS from 1-100")),
+			mcp.WithString("status", mcp.Description("Filter by detection status: Active, Fixed, New")),
+			mcp.WithNumber("limit", mcp.Description("Maximum detections to analyze (default 200)")),
+		),
+		m.getDetectionStats,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_get_detection_summary",
+			mcp.WithDescription("RECOMMENDED: Get summarized view with stats, top 10 risk hosts, and top 20 findings. Faster than full search. Always filter by severity:5 for critical-only."),
+			mcp.WithString("qids", mcp.Description("QID or comma-separated list of QIDs to filter")),
+			mcp.WithNumber("severity", mcp.Description("Filter by minimum severity (1-5, where 5 is critical). Recommended: 5")),
+			mcp.WithNumber("qds_min", mcp.Description("Filter by minimum QDS from 1-100")),
+			mcp.WithString("status", mcp.Description("Filter by detection status: Active, Fixed, New")),
+			mcp.WithNumber("limit", mcp.Description("Maximum detections to analyze (default 200)")),
+		),
+		m.getDetectionSummary,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_list_scans",
+			mcp.WithDescription("List recent vulnerability scans. Shows scan status, launch date, and targets."),
+			mcp.WithString("status", mcp.Description("Filter by scan status: Running, Paused, Canceled, Finished, Error")),
+			mcp.WithNumber("limit", mcp.Description("Maximum number of scans to return")),
+		),
+		m.listScans,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_get_scan_results",
+			mcp.WithDescription("Get detailed results from a specific vulnerability scan."),
+			mcp.WithString("scan_ref", mcp.Required(), mcp.Description("The scan reference ID (e.g., scan/1234567890.12345)")),
+		),
+		m.getScanResults,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_list_asset_groups",
+			mcp.WithDescription("List all asset groups defined in VMDR. Asset groups organize hosts for scanning and reporting."),
+		),
+		m.listAssetGroups,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_get_scan_schedules",
+			mcp.WithDescription("List all scheduled vulnerability scans with next run time, option profile, and targets."),
+		),
+		m.getScanSchedules,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_get_option_profiles",
+			mcp.WithDescription("List scan option profiles available for vulnerability scanning. Shows profile name, owner, and default status."),
+		),
+		m.getOptionProfiles,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_get_ip_list",
+			mcp.WithDescription("List tracked IPs and IP ranges in the Qualys subscription."),
+		),
+		m.getIPList,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_launch_scan",
+			mcp.WithDescription("Launch an on-demand vulnerability scan. Requires scan title, option profile name, and target IPs."),
+			mcp.WithString("title", mcp.Required(), mcp.Description("Title for the scan")),
+			mcp.WithString("option_profile", mcp.Required(), mcp.Description("Name of the option profile to use for scanning")),
+			mcp.WithString("targets", mcp.Required(), mcp.Description("Target IPs or IP ranges to scan (comma-separated)")),
+		),
+		m.launchScan,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_get_scan_status",
+			mcp.WithDescription("Get scan status with progress percentage and estimated completion. Use to monitor running scans."),
+			mcp.WithString("scan_ref", mcp.Required(), mcp.Description("The scan reference ID (e.g., scan/1234567890.12345)")),
+		),
+		m.getScanStatus,
+	)
+
+	s.AddTool(
+		mcp.NewTool("vmdr_get_coverage_gaps",
+			mcp.WithDescription("Find assets not scanned within a given number of days. Helps identify scan coverage gaps and stale assets."),
+			mcp.WithNumber("days_threshold", mcp.Description("Number of days without a scan to flag as a gap (default 7)")),
+			mcp.WithNumber("limit", mcp.Description("Maximum number of hosts to check (default 100)")),
+		),
+		m.getCoverageGaps,
+	)
+}
+
+func (m *Module) listHosts(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	filter, _ := req.Params.Arguments["filter"].(string)
+	limit := 100
+	if l, ok := req.Params.Arguments["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	hosts, err := m.client.ListHosts(ctx, filter, limit)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list hosts: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(hosts, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getHostDetections(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	hostID, ok := req.Params.Arguments["host_id"].(string)
+	if !ok || hostID == "" {
+		return newToolResultError("host_id is required"), nil
+	}
+
+	severity := 0
+	if s, ok := req.Params.Arguments["severity"].(float64); ok {
+		severity = int(s)
+	}
+
+	qdsMin := 0
+	if q, ok := req.Params.Arguments["qds_min"].(float64); ok {
+		qdsMin = int(q)
+	}
+
+	detections, err := m.client.GetHostDetections(ctx, hostID, severity, qdsMin)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get detections: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(detections, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) searchDetections(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	qids, _ := req.Params.Arguments["qids"].(string)
+	status, _ := req.Params.Arguments["status"].(string)
+	outputMode, _ := req.Params.Arguments["output_mode"].(string)
+
+	severity := 0
+	if s, ok := req.Params.Arguments["severity"].(float64); ok {
+		severity = int(s)
+	}
+
+	qdsMin := 0
+	if q, ok := req.Params.Arguments["qds_min"].(float64); ok {
+		qdsMin = int(q)
+	}
+
+	limit := 50
+	if l, ok := req.Params.Arguments["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	if outputMode == "" {
+		if qids != "" {
+			outputMode = "full"
+		} else if severity > 0 || qdsMin > 0 || status != "" {
+			outputMode = "brief"
+		} else {
+			outputMode = "stats"
+		}
+	}
+
+	if outputMode == "stats" {
+		stats, err := m.client.GetDetectionStats(ctx, qids, severity, qdsMin, status, limit)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("Failed to get detection stats: %v", err)), nil
+		}
+		data, _ := json.MarshalIndent(stats, "", "  ")
+		return mcp.NewToolResultText(string(data)), nil
+	}
+
+	detections, err := m.client.SearchDetectionsWithStatus(ctx, qids, severity, qdsMin, limit, status)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to search detections: %v", err)), nil
+	}
+
+	if outputMode == "brief" {
+		type BriefDetection struct {
+			QID      int    `json:"qid"`
+			Severity int    `json:"severity"`
+			Status   string `json:"status"`
+		}
+		type BriefHost struct {
+			HostID     string           `json:"hostId"`
+			IP         string           `json:"ip"`
+			Detections []BriefDetection `json:"detections"`
+		}
+		var brief []BriefHost
+		for _, h := range detections {
+			bh := BriefHost{
+				HostID: h.Host.ID,
+				IP:     h.Host.IP,
+			}
+			for _, d := range h.Detections {
+				bh.Detections = append(bh.Detections, BriefDetection{
+					QID:      d.QID,
+					Severity: d.Severity,
+					Status:   d.Status,
+				})
+			}
+			brief = append(brief, bh)
+		}
+		data, _ := json.MarshalIndent(brief, "", "  ")
+		return mcp.NewToolResultText(string(data)), nil
+	}
+
+	data, _ := json.MarshalIndent(detections, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getDetectionStats(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	qids, _ := req.Params.Arguments["qids"].(string)
+	status, _ := req.Params.Arguments["status"].(string)
+
+	severity := 0
+	if s, ok := req.Params.Arguments["severity"].(float64); ok {
+		severity = int(s)
+	}
+
+	qdsMin := 0
+	if q, ok := req.Params.Arguments["qds_min"].(float64); ok {
+		qdsMin = int(q)
+	}
+
+	limit := 200
+	if l, ok := req.Params.Arguments["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	stats, err := m.client.GetDetectionStats(ctx, qids, severity, qdsMin, status, limit)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get detection stats: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(stats, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getDetectionSummary(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	qids, _ := req.Params.Arguments["qids"].(string)
+	status, _ := req.Params.Arguments["status"].(string)
+
+	severity := 0
+	if s, ok := req.Params.Arguments["severity"].(float64); ok {
+		severity = int(s)
+	}
+
+	qdsMin := 0
+	if q, ok := req.Params.Arguments["qds_min"].(float64); ok {
+		qdsMin = int(q)
+	}
+
+	limit := 200
+	if l, ok := req.Params.Arguments["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	summary, err := m.client.GetDetectionSummary(ctx, qids, severity, qdsMin, status, limit)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get detection summary: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(summary, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) listScans(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	status, _ := req.Params.Arguments["status"].(string)
+	limit := 50
+	if l, ok := req.Params.Arguments["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	scans, err := m.client.ListScans(ctx, status, limit)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list scans: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(scans, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getScanResults(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	scanRef, ok := req.Params.Arguments["scan_ref"].(string)
+	if !ok || scanRef == "" {
+		return newToolResultError("scan_ref is required"), nil
+	}
+
+	detections, err := m.client.GetScanResults(ctx, scanRef)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get scan results: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(detections, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) listAssetGroups(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	groups, err := m.client.ListAssetGroups(ctx)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to list asset groups: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(groups, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getScanSchedules(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	schedules, err := m.client.GetScanSchedules(ctx)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get scan schedules: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(schedules, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getOptionProfiles(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	profiles, err := m.client.GetOptionProfiles(ctx)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get option profiles: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(profiles, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getIPList(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ips, err := m.client.GetIPList(ctx)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get IP list: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(ips, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) launchScan(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	title, ok := req.Params.Arguments["title"].(string)
+	if !ok || title == "" {
+		return newToolResultError("title is required"), nil
+	}
+
+	optionProfile, ok := req.Params.Arguments["option_profile"].(string)
+	if !ok || optionProfile == "" {
+		return newToolResultError("option_profile is required"), nil
+	}
+
+	targets, ok := req.Params.Arguments["targets"].(string)
+	if !ok || targets == "" {
+		return newToolResultError("targets is required"), nil
+	}
+
+	result, err := m.client.LaunchScan(ctx, title, optionProfile, targets)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to launch scan: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getScanStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	scanRef, ok := req.Params.Arguments["scan_ref"].(string)
+	if !ok || scanRef == "" {
+		return newToolResultError("scan_ref is required"), nil
+	}
+
+	status, err := m.client.GetScanStatus(ctx, scanRef)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get scan status: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(status, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getCoverageGaps(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	daysThreshold := 7
+	if d, ok := req.Params.Arguments["days_threshold"].(float64); ok {
+		daysThreshold = int(d)
+	}
+
+	limit := 100
+	if l, ok := req.Params.Arguments["limit"].(float64); ok {
+		limit = int(l)
+	}
+
+	gaps, err := m.client.GetCoverageGaps(ctx, daysThreshold, limit)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get coverage gaps: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(gaps, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}


### PR DESCRIPTION
Addresses issue #46

## New MCP Tools

| Tool | Description |
|------|-------------|
| `vmdr_get_scan_schedules` | Lists all scheduled scans with next run time, option profile, and targets |
| `vmdr_get_option_profiles` | Lists scan option profiles (name, owner, default status) |
| `vmdr_get_ip_list` | Lists tracked IPs and IP ranges in the subscription |
| `vmdr_launch_scan` | Launches an on-demand scan (title, option_profile, targets) |
| `vmdr_get_scan_status` | Enhanced scan status with progress % for running scans |
| `vmdr_get_coverage_gaps` | Finds assets not scanned within N days (default 7), sorted by staleness |

## Implementation Details

- New client methods in `internal/modules/vmdr/client.go`: `GetScanSchedules`, `GetOptionProfiles`, `GetIPList`, `LaunchScan`, `GetScanStatus`, `GetCoverageGaps`
- New tool registrations in `internal/modules/vmdr/tools.go`
- Uses Qualys v2 APIs: schedule/scan, option_profile/vm, asset/ip, scan launch/fetch/list
- Follows existing patterns: XML parsing, form-encoded POSTs, consistent JSON output formatting
- Project builds cleanly: `go build ./...` passes