### PR TITLE
feat: add get_activity_log tool for activity log and audit trail (#48)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -105,7 +105,7 @@ Set with: export QUALYS_POD=<pod>`)
 
 	modules := os.Getenv("QUALYS_MODULES")
 	if modules == "" {
-		modules = "vmdr,container,gav,knowledgebase,totalcloud,patch,edr,fim,was,compliance,certview,car,workflows"
+		modules = "vmdr,container,gav,knowledgebase,totalcloud,patch,edr,fim,was,compliance,certview,car,activitylog,workflows"
 	}
 
 	rateLimit := 100

--- a/internal/modules/activitylog/client.go
+++ b/internal/modules/activitylog/client.go
@@ -1,0 +1,274 @@
+package activitylog
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/nelssec/qualys-mcp/internal/common"
+)
+
+type Client struct {
+	http    *common.HTTPClient
+	baseURL string
+}
+
+func NewClient(http *common.HTTPClient, baseURL string) *Client {
+	return &Client{
+		http:    http,
+		baseURL: baseURL,
+	}
+}
+
+// ActivityLogEntry represents a single activity log event from Qualys.
+type ActivityLogEntry struct {
+	Date      string `xml:"DATE" json:"date"`
+	UserLogin string `xml:"USER_LOGIN" json:"userLogin"`
+	UserName  string `xml:"USER_NAME" json:"userName,omitempty"`
+	UserRole  string `xml:"USER_ROLE" json:"userRole,omitempty"`
+	UserIP    string `xml:"USER_IP" json:"userIp,omitempty"`
+	Action    string `xml:"ACTION" json:"action"`
+	Module    string `xml:"MODULE" json:"module,omitempty"`
+	Details   string `xml:"DETAILS" json:"details,omitempty"`
+}
+
+type activityLogResponse struct {
+	XMLName  xml.Name `xml:"ACTIVITY_LOG_OUTPUT"`
+	Response struct {
+		ActivityLogList []ActivityLogEntry `xml:"ACTIVITY_LOG_LIST>ACTIVITY_LOG_ENTRY"`
+	} `xml:"RESPONSE"`
+}
+
+// ActivityLogResult is the structured output returned by the tool.
+type ActivityLogResult struct {
+	TotalEntries int                `json:"totalEntries"`
+	DateRange    DateRange          `json:"dateRange"`
+	Entries      []ActivityLogEntry `json:"entries"`
+	Summary      ActivitySummary    `json:"summary"`
+}
+
+type DateRange struct {
+	Since string `json:"since"`
+	Until string `json:"until"`
+}
+
+type ActivitySummary struct {
+	ByUser   map[string]int `json:"byUser"`
+	ByAction map[string]int `json:"byAction"`
+	ByModule map[string]int `json:"byModule"`
+}
+
+// NotableChanges represents config drift and notable activity for the morning report.
+type NotableChanges struct {
+	DateRange        DateRange          `json:"dateRange"`
+	TotalEvents      int                `json:"totalEvents"`
+	ConfigDrift      []ActivityLogEntry `json:"configDrift,omitempty"`
+	PolicyChanges    []ActivityLogEntry `json:"policyChanges,omitempty"`
+	ScanActivity     []ActivityLogEntry `json:"scanActivity,omitempty"`
+	UserChanges      []ActivityLogEntry `json:"userChanges,omitempty"`
+	ExceptionChanges []ActivityLogEntry `json:"exceptionChanges,omitempty"`
+	Summary          string             `json:"summary"`
+}
+
+func (c *Client) GetActivityLog(ctx context.Context, days int, user string, action string) (*ActivityLogResult, error) {
+	if days <= 0 {
+		days = 7
+	}
+
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/activity_log/", c.baseURL)
+
+	now := time.Now().UTC()
+	since := now.Add(-time.Duration(days) * 24 * time.Hour)
+
+	params := url.Values{}
+	params.Set("action", "list")
+	params.Set("since_datetime", since.Format("2006-01-02T15:04:05Z"))
+	params.Set("until_datetime", now.Format("2006-01-02T15:04:05Z"))
+	params.Set("truncation_limit", "1000")
+	if user != "" {
+		params.Set("user_login", user)
+	}
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp activityLogResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	entries := resp.Response.ActivityLogList
+
+	// Apply action filter client-side (API may not support exact action filtering).
+	if action != "" {
+		actionLower := strings.ToLower(action)
+		var filtered []ActivityLogEntry
+		for _, e := range entries {
+			if strings.Contains(strings.ToLower(e.Action), actionLower) {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	summary := ActivitySummary{
+		ByUser:   make(map[string]int),
+		ByAction: make(map[string]int),
+		ByModule: make(map[string]int),
+	}
+	for _, e := range entries {
+		summary.ByUser[e.UserLogin]++
+		summary.ByAction[e.Action]++
+		if e.Module != "" {
+			summary.ByModule[e.Module]++
+		}
+	}
+
+	return &ActivityLogResult{
+		TotalEntries: len(entries),
+		DateRange: DateRange{
+			Since: since.Format("2006-01-02T15:04:05Z"),
+			Until: now.Format("2006-01-02T15:04:05Z"),
+		},
+		Entries: entries,
+		Summary: summary,
+	}, nil
+}
+
+// GetNotableChanges returns activity categorized for morning report integration.
+// Looks at the last 24 hours by default and categorizes events into config drift,
+// policy changes, scan activity, user changes, and exception acknowledgements.
+func (c *Client) GetNotableChanges(ctx context.Context, hours int) (*NotableChanges, error) {
+	if hours <= 0 {
+		hours = 24
+	}
+
+	endpoint := fmt.Sprintf("%s/api/2.0/fo/activity_log/", c.baseURL)
+
+	now := time.Now().UTC()
+	since := now.Add(-time.Duration(hours) * time.Hour)
+
+	params := url.Values{}
+	params.Set("action", "list")
+	params.Set("since_datetime", since.Format("2006-01-02T15:04:05Z"))
+	params.Set("until_datetime", now.Format("2006-01-02T15:04:05Z"))
+	params.Set("truncation_limit", "1000")
+
+	data, err := c.http.Get(ctx, endpoint+"?"+params.Encode())
+	if err != nil {
+		return nil, err
+	}
+
+	var resp activityLogResponse
+	if err := xml.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	entries := resp.Response.ActivityLogList
+	result := &NotableChanges{
+		DateRange: DateRange{
+			Since: since.Format("2006-01-02T15:04:05Z"),
+			Until: now.Format("2006-01-02T15:04:05Z"),
+		},
+		TotalEvents: len(entries),
+	}
+
+	for _, e := range entries {
+		actionLower := strings.ToLower(e.Action)
+		detailsLower := strings.ToLower(e.Details)
+		combined := actionLower + " " + detailsLower
+
+		switch {
+		case isConfigDrift(combined):
+			result.ConfigDrift = append(result.ConfigDrift, e)
+		case isPolicyChange(combined):
+			result.PolicyChanges = append(result.PolicyChanges, e)
+		case isScanActivity(combined):
+			result.ScanActivity = append(result.ScanActivity, e)
+		case isUserChange(combined):
+			result.UserChanges = append(result.UserChanges, e)
+		case isExceptionChange(combined):
+			result.ExceptionChanges = append(result.ExceptionChanges, e)
+		}
+	}
+
+	// Build summary text.
+	var parts []string
+	if len(result.ConfigDrift) > 0 {
+		parts = append(parts, fmt.Sprintf("%d config change(s)", len(result.ConfigDrift)))
+	}
+	if len(result.PolicyChanges) > 0 {
+		parts = append(parts, fmt.Sprintf("%d policy change(s)", len(result.PolicyChanges)))
+	}
+	if len(result.ScanActivity) > 0 {
+		parts = append(parts, fmt.Sprintf("%d scan event(s)", len(result.ScanActivity)))
+	}
+	if len(result.UserChanges) > 0 {
+		parts = append(parts, fmt.Sprintf("%d user change(s)", len(result.UserChanges)))
+	}
+	if len(result.ExceptionChanges) > 0 {
+		parts = append(parts, fmt.Sprintf("%d exception change(s)", len(result.ExceptionChanges)))
+	}
+	if len(parts) == 0 {
+		result.Summary = "No notable changes in the last " + fmt.Sprintf("%d", hours) + " hours."
+	} else {
+		result.Summary = fmt.Sprintf("Notable changes (%d total events): %s", result.TotalEvents, strings.Join(parts, ", "))
+	}
+
+	return result, nil
+}
+
+func isConfigDrift(s string) bool {
+	keywords := []string{"scanner", "option profile", "appliance", "connector", "virtual scanner", "network", "map"}
+	for _, kw := range keywords {
+		if strings.Contains(s, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPolicyChange(s string) bool {
+	keywords := []string{"policy", "compliance", "control", "benchmark"}
+	for _, kw := range keywords {
+		if strings.Contains(s, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func isScanActivity(s string) bool {
+	keywords := []string{"scan", "launch", "schedule", "cancel"}
+	for _, kw := range keywords {
+		if strings.Contains(s, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func isUserChange(s string) bool {
+	keywords := []string{"user", "role", "permission", "login", "password", "account"}
+	for _, kw := range keywords {
+		if strings.Contains(s, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func isExceptionChange(s string) bool {
+	keywords := []string{"exception", "acknowledge", "whitelist", "ignore", "approve", "waive"}
+	for _, kw := range keywords {
+		if strings.Contains(s, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/modules/activitylog/tools.go
+++ b/internal/modules/activitylog/tools.go
@@ -1,0 +1,82 @@
+package activitylog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nelssec/qualys-mcp/internal/common"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+var newToolResultError = common.NewToolResultError
+
+type Module struct {
+	client *Client
+}
+
+func New(http *common.HTTPClient, baseURL string) *Module {
+	return &Module{
+		client: NewClient(http, baseURL),
+	}
+}
+
+func NewWithClient(client *Client) *Module {
+	return &Module{
+		client: client,
+	}
+}
+
+func (m *Module) RegisterTools(s *server.MCPServer) {
+	s.AddTool(
+		mcp.NewTool("get_activity_log",
+			mcp.WithDescription("Get the Qualys activity log for audit trail and compliance. Shows who ran scans, changed policies, acknowledged exceptions, and modified configuration. Useful for change management, compliance audits, and detecting config drift."),
+			mcp.WithNumber("days", mcp.Description("Number of days to look back (default: 7)")),
+			mcp.WithString("user", mcp.Description("Filter by username/login")),
+			mcp.WithString("action", mcp.Description("Filter by action type (e.g., 'scan', 'policy', 'user')")),
+		),
+		m.getActivityLog,
+	)
+
+	s.AddTool(
+		mcp.NewTool("get_notable_changes",
+			mcp.WithDescription("Get notable changes since yesterday for morning report. Categorizes recent activity into: config drift (new scanners, option profile changes), policy changes, scan launches/completions, user additions/removals, and exception acknowledgements. Use for daily briefings and change management."),
+			mcp.WithNumber("hours", mcp.Description("Number of hours to look back (default: 24)")),
+		),
+		m.getNotableChanges,
+	)
+}
+
+func (m *Module) getActivityLog(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	days := 7
+	if d, ok := req.Params.Arguments["days"].(float64); ok && d > 0 {
+		days = int(d)
+	}
+
+	user, _ := req.Params.Arguments["user"].(string)
+	action, _ := req.Params.Arguments["action"].(string)
+
+	result, err := m.client.GetActivityLog(ctx, days, user, action)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get activity log: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (m *Module) getNotableChanges(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	hours := 24
+	if h, ok := req.Params.Arguments["hours"].(float64); ok && h > 0 {
+		hours = int(h)
+	}
+
+	result, err := m.client.GetNotableChanges(ctx, hours)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to get notable changes: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}

--- a/internal/modules/workflows/client.go
+++ b/internal/modules/workflows/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/nelssec/qualys-mcp/internal/modules/activitylog"
 	"github.com/nelssec/qualys-mcp/internal/modules/car"
 	"github.com/nelssec/qualys-mcp/internal/modules/compliance"
 	"github.com/nelssec/qualys-mcp/internal/modules/container"
@@ -20,15 +21,16 @@ import (
 )
 
 type Client struct {
-	gav        *gav.Client
-	vmdr       *vmdr.Client
-	kb         *knowledgebase.Client
-	pm         *patch.Client
-	car        *car.Client
-	was        *was.Client
-	container  *container.Client
-	totalcloud *totalcloud.Client
-	compliance *compliance.Client
+	gav         *gav.Client
+	vmdr        *vmdr.Client
+	kb          *knowledgebase.Client
+	pm          *patch.Client
+	car         *car.Client
+	was         *was.Client
+	container   *container.Client
+	totalcloud  *totalcloud.Client
+	compliance  *compliance.Client
+	activitylog *activitylog.Client
 }
 
 func NewClient(gavClient *gav.Client, vmdrClient *vmdr.Client, kbClient *knowledgebase.Client, pmClient *patch.Client, carClient *car.Client) *Client {
@@ -64,17 +66,18 @@ func NewClientFull(gavClient *gav.Client, vmdrClient *vmdr.Client, kbClient *kno
 	}
 }
 
-func NewClientComplete(gavClient *gav.Client, vmdrClient *vmdr.Client, kbClient *knowledgebase.Client, pmClient *patch.Client, carClient *car.Client, wasClient *was.Client, containerClient *container.Client, tcClient *totalcloud.Client, pcClient *compliance.Client) *Client {
+func NewClientComplete(gavClient *gav.Client, vmdrClient *vmdr.Client, kbClient *knowledgebase.Client, pmClient *patch.Client, carClient *car.Client, wasClient *was.Client, containerClient *container.Client, tcClient *totalcloud.Client, pcClient *compliance.Client, alClient *activitylog.Client) *Client {
 	return &Client{
-		gav:        gavClient,
-		vmdr:       vmdrClient,
-		kb:         kbClient,
-		pm:         pmClient,
-		car:        carClient,
-		was:        wasClient,
-		container:  containerClient,
-		totalcloud: tcClient,
-		compliance: pcClient,
+		gav:         gavClient,
+		vmdr:        vmdrClient,
+		kb:          kbClient,
+		pm:          pmClient,
+		car:         carClient,
+		was:         wasClient,
+		container:   containerClient,
+		totalcloud:  tcClient,
+		compliance:  pcClient,
+		activitylog: alClient,
 	}
 }
 
@@ -1388,7 +1391,18 @@ type SecurityPosture struct {
 	ContainerStats  ContainerPostureStats  `json:"containerStats,omitempty"`
 	CloudStats      CloudPostureStats      `json:"cloudStats,omitempty"`
 	ComplianceStats CompliancePostureStats `json:"complianceStats,omitempty"`
+	NotableChanges  *NotableChangesStats   `json:"notableChanges,omitempty"`
 	Warnings        []string               `json:"warnings,omitempty"`
+}
+
+type NotableChangesStats struct {
+	TotalEvents      int    `json:"totalEvents"`
+	ConfigDrift      int    `json:"configDrift"`
+	PolicyChanges    int    `json:"policyChanges"`
+	ScanActivity     int    `json:"scanActivity"`
+	UserChanges      int    `json:"userChanges"`
+	ExceptionChanges int    `json:"exceptionChanges"`
+	Summary          string `json:"summary"`
 }
 
 type AssetPostureStats struct {
@@ -1658,6 +1672,32 @@ func (c *Client) GetSecurityPosture(ctx context.Context) (*SecurityPosture, erro
 			mu.Lock()
 			result.ComplianceStats.TotalPolicies = len(policies)
 			result.ComplianceStats.ActiveScans = len(scans)
+			mu.Unlock()
+		}()
+	}
+
+	// Goroutine 6: Activity log notable changes (last 24h)
+	if c.activitylog != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			changes, err := c.activitylog.GetNotableChanges(ctx, 24)
+			if err != nil {
+				mu.Lock()
+				result.Warnings = append(result.Warnings, "Activity log unavailable")
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			result.NotableChanges = &NotableChangesStats{
+				TotalEvents:      changes.TotalEvents,
+				ConfigDrift:      len(changes.ConfigDrift),
+				PolicyChanges:    len(changes.PolicyChanges),
+				ScanActivity:     len(changes.ScanActivity),
+				UserChanges:      len(changes.UserChanges),
+				ExceptionChanges: len(changes.ExceptionChanges),
+				Summary:          changes.Summary,
+			}
 			mu.Unlock()
 		}()
 	}

--- a/internal/modules/workflows/tools.go
+++ b/internal/modules/workflows/tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/nelssec/qualys-mcp/internal/common"
+	"github.com/nelssec/qualys-mcp/internal/modules/activitylog"
 	"github.com/nelssec/qualys-mcp/internal/modules/car"
 	"github.com/nelssec/qualys-mcp/internal/modules/compliance"
 	"github.com/nelssec/qualys-mcp/internal/modules/container"
@@ -43,9 +44,9 @@ func NewFull(gavClient *gav.Client, vmdrClient *vmdr.Client, kbClient *knowledge
 	}
 }
 
-func NewComplete(gavClient *gav.Client, vmdrClient *vmdr.Client, kbClient *knowledgebase.Client, pmClient *patch.Client, carClient *car.Client, wasClient *was.Client, containerClient *container.Client, tcClient *totalcloud.Client, pcClient *compliance.Client) *Module {
+func NewComplete(gavClient *gav.Client, vmdrClient *vmdr.Client, kbClient *knowledgebase.Client, pmClient *patch.Client, carClient *car.Client, wasClient *was.Client, containerClient *container.Client, tcClient *totalcloud.Client, pcClient *compliance.Client, alClient *activitylog.Client) *Module {
 	return &Module{
-		client: NewClientComplete(gavClient, vmdrClient, kbClient, pmClient, carClient, wasClient, containerClient, tcClient, pcClient),
+		client: NewClientComplete(gavClient, vmdrClient, kbClient, pmClient, carClient, wasClient, containerClient, tcClient, pcClient, alClient),
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nelssec/qualys-mcp/config"
 	"github.com/nelssec/qualys-mcp/internal/auth"
 	"github.com/nelssec/qualys-mcp/internal/common"
+	"github.com/nelssec/qualys-mcp/internal/modules/activitylog"
 	"github.com/nelssec/qualys-mcp/internal/modules/car"
 	"github.com/nelssec/qualys-mcp/internal/modules/certview"
 	"github.com/nelssec/qualys-mcp/internal/modules/compliance"
@@ -155,8 +156,15 @@ func (s *Server) registerModules() {
 		remediationModule.RegisterTools(s.mcp)
 	}
 
+	var alClient *activitylog.Client
+	if s.config.IsModuleEnabled("activitylog") {
+		alClient = activitylog.NewClient(s.http, s.config.BaseURL)
+		alModule := activitylog.NewWithClient(alClient)
+		alModule.RegisterTools(s.mcp)
+	}
+
 	if s.config.IsModuleEnabled("workflows") {
-		workflowsModule := workflows.NewComplete(gavClient, vmdrClient, kbClient, pmClient, carClient, wasClient, containerClient, tcClient, pcClient)
+		workflowsModule := workflows.NewComplete(gavClient, vmdrClient, kbClient, pmClient, carClient, wasClient, containerClient, tcClient, pcClient, alClient)
 		workflowsModule.RegisterTools(s.mcp)
 	}
 }


### PR DESCRIPTION
Addresses issue #48

## Summary

Implements a new  MCP tool that exposes the Qualys activity log for compliance and change management use cases.

## Changes

- **New module**  with:
  - : Qualys Activity Log API client supporting filtering by days, user, and action type
  - : MCP tool registration with  signature
- **Updated**  to register the new activitylog module
- **Updated**  to support activity log configuration
- **Enhanced**  for morning report integration including 'notable changes since yesterday'

## Features

- Query activity log by time range (default: last 7 days)
- Filter by username and/or action type
- Surfaces compliance-relevant events: scan launches, policy changes, exception acknowledgements
- Detects config drift: new scanners added, option profiles changed
- Integrated into morning report as 'notable changes since yesterday'