### PR TITLE
fix: use BASE_URL with basic auth for CloudView connector and evaluation endpoints (#86)

### DIFF
--- a/docs/query-languages.md
+++ b/docs/query-languages.md
@@ -530,11 +530,14 @@ GET /cdr-api/rest/v1/findings/?startAt=ISO&endAt=ISO&{params}
 
 ### Cloud Connector/Evaluation Endpoints
 ```
-GET /cloudview-api/rest/v1/{provider}/connectors?pageSize=50
-GET /cloudview-api/rest/v1/{provider}/evaluations/{account_id}?pageSize=500
+GET {BASE_URL}/cloudview-api/rest/v1/{provider}/connectors?pageSize=50
+GET {BASE_URL}/cloudview-api/rest/v1/{provider}/evaluations/{account_id}?pageSize=500
 ```
 
 Providers: `aws`, `azure`, `gcp`
+
+> **Note:** CloudView connector and evaluation endpoints require `BASE_URL` with basic
+> auth — they do not work through `GATEWAY_URL` with JWT (GCP/Azure return 404).
 
 ### Common CDR Examples
 

--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -751,16 +751,18 @@ def get_containers(limit=100, count_only=False):
 
 
 def get_connectors(provider='aws', limit=50):
-    url = f"{GATEWAY_URL}/cloudview-api/rest/v1/{provider}/connectors"
+    url = f"{BASE_URL}/cloudview-api/rest/v1/{provider}/connectors"
     # 404 = no connectors configured for this provider — valid state, return empty list
     return _paginate_json(url, limit, data_key='content', count_key='totalElements',
-                          page_param='pageNo', size_param='pageSize', not_found_ok=True)
+                          page_param='pageNo', size_param='pageSize',
+                          gateway=False, not_found_ok=True)
 
 
 def get_evaluations(account_id, provider='aws', limit=500):
-    url = f"{GATEWAY_URL}/cloudview-api/rest/v1/{provider}/evaluations/{account_id}"
+    url = f"{BASE_URL}/cloudview-api/rest/v1/{provider}/evaluations/{account_id}"
     return _paginate_json(url, limit, data_key='content', count_key='totalElements',
-                          page_param='pageNo', size_param='pageSize')
+                          page_param='pageNo', size_param='pageSize',
+                          gateway=False)
 
 
 def get_cdr(days=7, limit=100, severity=None, cloud_provider=None, category=None):


### PR DESCRIPTION
Addresses issue #86

## Root Cause

`get_connectors()` and `get_evaluations()` were hitting `GATEWAY_URL` with JWT bearer auth. The CloudView API for GCP and Azure only works via `BASE_URL` with basic auth (username/password). AWS connectors happened to work through the gateway, masking the bug.

## Fix

- `get_connectors()`: changed URL from `GATEWAY_URL` to `BASE_URL`, added `gateway=False` so `_paginate_json()` uses basic auth
- `get_evaluations()`: same change — `BASE_URL` + `gateway=False`
- Both AWS and GCP/Azure now use the same consistent auth path

## Docs

- `docs/query-languages.md`: added note confirming provider strings (`aws`, `gcp`, `azure`) and that CloudView endpoints require `BASE_URL` with basic auth, not the gateway