### PR TITLE
feat: replace keyword-match eval with threshold-based quality scoring (#85)

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -420,6 +420,7 @@ def main():
             "timestamp": datetime.now().isoformat(),
             "score_pct": round(score_pct, 1),
             "threshold": threshold,
+            "keyword_match_threshold": KEYWORD_MATCH_THRESHOLD,
             "total": len(results),
             "passed": sum(1 for r in results if r["status"] == "pass"),
             "failed": sum(1 for r in results if r["status"] == "fail"),


### PR DESCRIPTION
Addresses issue #85

## Changes

Replaces the misleading single-keyword eval scoring in `eval.py` with meaningful quality checks:

### Scoring improvements
- **Multi-keyword threshold**: requires ≥50% of expected keywords to match (was: any 1 keyword)
- **Result validity check**: rejects empty, too-short (<50 chars), or error-only responses
- **Tool-specific validators** for critical tools:
  - `get_security_posture`: verifies numeric trurisk score present
  - `get_cloud_risk`: requires actual cloud provider keywords (aws/azure/gcp), not just "cloud"
  - `investigate_cve`: requires CVE pattern in response
  - `get_patch_status`: requires numeric coverage percentage

### Keyword list improvements
- Replaced generic words ("cloud", "risk", "asset") that match error messages with domain-specific terms ("cloud_provider", "risk_distribution", "trurisk_score")

### Transparency
- Match ratio shown in output (e.g., `3/4 keywords`)
- Failure reason displayed on next line for failed evals
- JSON output includes `keyword_match_threshold` field

The `eval/` module (Claude-as-judge, full MCP runner) is unchanged — this PR improves the fast standalone `eval.py` path.