### PR TITLE
fix: get_asset_inventory uses invalid CSAM filter field

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -5253,7 +5253,7 @@ def get_asset_inventory(query: str = "", tag: str = "", os: str = "", days_since
         filters.append({"field": "asset.name", "operator": "CONTAINS", "value": query})
     if days_since_seen > 0:
         cutoff = (datetime.now(timezone.utc) - timedelta(days=days_since_seen)).strftime('%Y-%m-%dT00:00:00Z')
-        filters.append({"field": "asset.lastSeen", "operator": "LESS", "value": cutoff})
+        filters.append({"field": "asset.lastUpdatedDate", "operator": "LESS", "value": cutoff})
     if eol_only:
         filters.append({"field": "operatingSystem.lifecycle.stage", "operator": "CONTAINS", "value": "EOL"})
 


### PR DESCRIPTION
## Summary
- Replace invalid `asset.lastSeen` filter field with `asset.lastUpdatedDate` in `get_asset_inventory()` to fix HTTP 400 errors when using the `days_since_seen` parameter

Fixes #105

## Test plan
- [ ] Call `get_asset_inventory` with `days_since_seen > 0` and confirm no HTTP 400 error
- [ ] Verify returned assets are filtered by last updated date correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)