### PR TITLE
feat: multi-turn conversation eval (#110)

### DIFF
--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -19,15 +19,16 @@ import anthropic
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
 
-from .judge import judge_response
+from .judge import CONV_SCORE_WEIGHTS, judge_conversation_turn, judge_response
 from .parser import QUESTIONS_PATH, parse_questions
 from .reporter import (
+    RESULTS_DIR,
     compute_summary,
     get_previous_run,
     print_summary,
     save_results,
 )
-from .runner import MODEL, get_mcp_tools, get_server_params, run_question
+from .runner import MODEL, get_mcp_tools, get_server_params, run_conversation, run_question
 from .updater import update_questions_file
 
 
@@ -153,6 +154,216 @@ async def run_eval(args):
         print(f"PASS: score {summary['overall_score']:.1%} >= threshold {args.threshold:.0%}")
 
 
+async def run_conversation_eval(args):
+    """Run multi-turn conversation evaluation."""
+    import json as _json
+    from pathlib import Path
+
+    conv_path = Path(__file__).parent / "conversations.json"
+    with open(conv_path) as f:
+        conversations = _json.load(f)
+
+    if args.limit:
+        conversations = conversations[: args.limit]
+
+    print(f"Conversation eval: {len(conversations)} scenarios")
+    print(f"Threshold: {args.threshold}")
+    print()
+
+    # Validate env vars
+    for var in ["QUALYS_USERNAME", "QUALYS_PASSWORD", "QUALYS_BASE_URL", "ANTHROPIC_API_KEY"]:
+        if not os.environ.get(var):
+            print(f"Error: {var} not set")
+            sys.exit(1)
+
+    client = anthropic.Anthropic()
+    server_params = get_server_params()
+
+    all_scenario_results = []
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            tools = await get_mcp_tools(session)
+            print(f"MCP server connected: {len(tools)} tools available")
+            print()
+
+            for conv in conversations:
+                scenario_id = conv["id"]
+                title = conv["title"]
+                category = conv["category"]
+                turns = conv["turns"]
+
+                print(f"[{scenario_id:>2}/{len(conversations)}] {title} ({len(turns)} turns)")
+
+                try:
+                    turn_results = await run_conversation(
+                        client, session, tools, turns
+                    )
+                except Exception as e:
+                    print(f"  FATAL: {e}")
+                    all_scenario_results.append(
+                        {
+                            "id": scenario_id,
+                            "title": title,
+                            "category": category,
+                            "turns": [
+                                {
+                                    "turn": i + 1,
+                                    "question": t,
+                                    "score": "tool-error",
+                                    "reasoning": f"Scenario failed: {e}",
+                                    "tool_calls": [],
+                                    "response": "",
+                                }
+                                for i, t in enumerate(turns)
+                            ],
+                            "scenario_score": 0.0,
+                        }
+                    )
+                    continue
+
+                # Score each turn
+                scored_turns = []
+                history_lines = []
+                for tr in turn_results:
+                    history_text = "\n".join(history_lines) if history_lines else "(start of conversation)"
+
+                    try:
+                        judgment = judge_conversation_turn(
+                            client,
+                            history_text,
+                            tr["question"],
+                            tr["tool_calls"],
+                            tr["response"],
+                        )
+                    except Exception as e:
+                        judgment = {"score": "tool-error", "reasoning": f"Judge error: {e}"}
+
+                    icon = {
+                        "correct": "✅",
+                        "partial": "⚠️",
+                        "wrong": "❌",
+                        "tool-error": "💥",
+                        "context-miss": "🔄",
+                        "off-track": "↗️",
+                    }.get(judgment["score"], "?")
+
+                    print(f"  T{tr['turn']}: {icon} {judgment['score']} — {judgment['reasoning'][:70]}")
+
+                    scored_turns.append(
+                        {
+                            "turn": tr["turn"],
+                            "question": tr["question"],
+                            "score": judgment["score"],
+                            "reasoning": judgment["reasoning"],
+                            "tool_calls": tr["tool_calls"],
+                            "response": tr["response"][:2000],
+                        }
+                    )
+
+                    # Build history for next turn's judge
+                    history_lines.append(f"User: {tr['question']}")
+                    history_lines.append(f"Assistant: {tr['response'][:500]}")
+
+                # Compute scenario score
+                turn_weights = [CONV_SCORE_WEIGHTS.get(t["score"], 0.0) for t in scored_turns]
+                scenario_score = sum(turn_weights) / len(turn_weights) if turn_weights else 0.0
+
+                score_icon = "✅" if scenario_score >= 0.7 else "⚠️" if scenario_score >= 0.4 else "❌"
+                print(f"  {score_icon} Scenario score: {scenario_score:.0%}")
+                print()
+
+                all_scenario_results.append(
+                    {
+                        "id": scenario_id,
+                        "title": title,
+                        "category": category,
+                        "turns": scored_turns,
+                        "scenario_score": round(scenario_score, 4),
+                    }
+                )
+
+    # Aggregate results
+    total_scenarios = len(all_scenario_results)
+    overall_score = (
+        sum(s["scenario_score"] for s in all_scenario_results) / total_scenarios
+        if total_scenarios
+        else 0
+    )
+
+    # Per-category
+    by_category: dict[str, list[float]] = {}
+    for s in all_scenario_results:
+        by_category.setdefault(s["category"], []).append(s["scenario_score"])
+    cat_scores = {cat: sum(scores) / len(scores) for cat, scores in by_category.items()}
+
+    # Collect turn-level score counts
+    all_scores = {"correct": 0, "partial": 0, "wrong": 0, "tool-error": 0, "context-miss": 0, "off-track": 0}
+    for s in all_scenario_results:
+        for t in s["turns"]:
+            all_scores[t["score"]] = all_scores.get(t["score"], 0) + 1
+    total_turns = sum(all_scores.values())
+
+    # Print summary
+    print(f"\n{'=' * 60}")
+    now = datetime.now(timezone.utc)
+    run_date = now.strftime("%Y-%m-%d_%H%M%S")
+    print(f"CONVERSATION EVAL RESULTS — {run_date}")
+    print(f"{'=' * 60}")
+    print(f"Scenarios: {total_scenarios}  |  Turns: {total_turns}  |  Score: {overall_score:.1%}")
+    print(
+        f"  correct: {all_scores['correct']}  partial: {all_scores['partial']}  "
+        f"wrong: {all_scores['wrong']}  tool-error: {all_scores['tool-error']}  "
+        f"context-miss: {all_scores['context-miss']}  off-track: {all_scores['off-track']}"
+    )
+    print()
+
+    # Per-scenario table
+    print(f"{'Scenario':<40} {'Score':>6}  {'Turns':>5}")
+    print("-" * 60)
+    for s in all_scenario_results:
+        icon = "✅" if s["scenario_score"] >= 0.7 else "⚠️" if s["scenario_score"] >= 0.4 else "❌"
+        print(f"{icon} {s['title']:<38} {s['scenario_score']:>5.0%}  {len(s['turns']):>5}")
+
+    print()
+    print(f"{'Category':<35} {'Score':>6}  {'Scenarios':>9}")
+    print("-" * 60)
+    for cat in sorted(cat_scores.keys()):
+        print(f"{cat:<35} {cat_scores[cat]:>5.0%}  {len(by_category[cat]):>9}")
+
+    # Save results
+    RESULTS_DIR.mkdir(exist_ok=True)
+    result_file = RESULTS_DIR / f"conv_{run_date}.json"
+    if result_file.exists():
+        i = 2
+        while (RESULTS_DIR / f"conv_{run_date}-{i}.json").exists():
+            i += 1
+        result_file = RESULTS_DIR / f"conv_{run_date}-{i}.json"
+
+    output = {
+        "run_date": run_date,
+        "model": MODEL,
+        "type": "conversation",
+        "total_scenarios": total_scenarios,
+        "total_turns": total_turns,
+        "overall_score": round(overall_score, 4),
+        "scored": all_scores,
+        "cat_scores": {cat: round(s, 4) for cat, s in cat_scores.items()},
+        "scenarios": all_scenario_results,
+    }
+    result_file.write_text(_json.dumps(output, indent=2))
+    print(f"\nResults saved to {result_file}")
+
+    # Threshold check
+    print(f"\n{'=' * 60}")
+    if overall_score < args.threshold:
+        print(f"FAIL: score {overall_score:.1%} < threshold {args.threshold:.0%}")
+        sys.exit(1)
+    else:
+        print(f"PASS: score {overall_score:.1%} >= threshold {args.threshold:.0%}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Eval harness for Qualys MCP Server",
@@ -164,6 +375,8 @@ def main():
   python -m eval --threshold 0.8            # Fail if score < 80%
   python -m eval --no-update                # Don't update questions.md
   python -m eval --concurrency 10           # 10 parallel workers
+  python -m eval --conversations            # Run multi-turn conversation eval
+  python -m eval --conversations --limit 5  # Run first 5 conversation scenarios
 """,
     )
     parser.add_argument(
@@ -200,15 +413,23 @@ def main():
         action="store_true",
         help="Don't auto-update coverage tags in docs/questions.md",
     )
+    parser.add_argument(
+        "--conversations",
+        action="store_true",
+        help="Run multi-turn conversation eval instead of single-question eval",
+    )
 
     args = parser.parse_args()
 
-    if args.quick:
-        if not args.limit:
-            args.limit = 20
-        args.concurrency = max(args.concurrency, 10)
+    if args.conversations:
+        asyncio.run(run_conversation_eval(args))
+    else:
+        if args.quick:
+            if not args.limit:
+                args.limit = 20
+            args.concurrency = max(args.concurrency, 10)
 
-    asyncio.run(run_eval(args))
+        asyncio.run(run_eval(args))
 
 
 if __name__ == "__main__":

--- a/eval/conversations.json
+++ b/eval/conversations.json
@@ -1,0 +1,304 @@
+[
+  {
+    "id": 1,
+    "title": "Monday Morning Standup",
+    "category": "Vulnerability Management",
+    "turns": [
+      "what happened over the weekend anything new",
+      "how critical is that log4j one",
+      "which servers are affected",
+      "are any of those in prod",
+      "ok can you give me a quick summary i can share with the team"
+    ]
+  },
+  {
+    "id": 2,
+    "title": "Ransomware Exposure Check",
+    "category": "Threat Intelligence",
+    "turns": [
+      "hey quick question — are we exposed to any ransomware-associated vulns right now",
+      "how many assets is that",
+      "which ones are the worst",
+      "what do we need to patch first",
+      "what's the realistic timeline if we started today"
+    ]
+  },
+  {
+    "id": 3,
+    "title": "CVE Incident Response — Log4Shell",
+    "category": "Vulnerability Management",
+    "turns": [
+      "CVE-2021-44228 just dropped on the news, are we affected",
+      "show me the affected assets",
+      "any of these have exceptions or are they all open",
+      "what's the patch",
+      "ok who owns these systems, can you tell from the tags",
+      "summarize this for a ticket"
+    ]
+  },
+  {
+    "id": 4,
+    "title": "New CVE Triage (Patch Tuesday)",
+    "category": "Vulnerability Management",
+    "turns": [
+      "patch tuesday was yesterday what do we need to care about",
+      "which of those are actually exploitable in the wild",
+      "focus on the windows ones, that's our main surface",
+      "how many assets",
+      "what's our patching coverage look like for these"
+    ]
+  },
+  {
+    "id": 5,
+    "title": "Single Asset Deep Dive",
+    "category": "Asset Management",
+    "turns": [
+      "why is server-prod-db-01 showing as high risk",
+      "what vulns does it have",
+      "is it running any EOL software",
+      "when was it last scanned",
+      "what would fix the most risk fastest"
+    ]
+  },
+  {
+    "id": 6,
+    "title": "Cloud Security Posture Review",
+    "category": "Cloud Security",
+    "turns": [
+      "i have a cloud security review tomorrow give me the overview",
+      "which cloud provider is worst",
+      "drill into azure what's failing",
+      "how many resources are affected",
+      "any of these are critical/internet-facing",
+      "give me an exec summary i can use in slides"
+    ]
+  },
+  {
+    "id": 7,
+    "title": "Compliance Audit Prep",
+    "category": "Compliance",
+    "turns": [
+      "pci audit in 2 weeks where do we stand",
+      "what controls are we failing",
+      "how many systems fail those controls",
+      "which failures are worst / highest impact",
+      "are there any exceptions we've approved that auditors will ask about",
+      "draft me a summary of our posture"
+    ]
+  },
+  {
+    "id": 8,
+    "title": "Container Security Review",
+    "category": "Container Security",
+    "turns": [
+      "what's the state of our container images",
+      "which images have the most critical vulns",
+      "what's actually running in prod right now",
+      "any of those running containers have unpatched criticals",
+      "what do we need to rebuild"
+    ]
+  },
+  {
+    "id": 9,
+    "title": "EOL / Tech Debt Discussion",
+    "category": "Asset Management",
+    "turns": [
+      "how bad is our tech debt",
+      "which eol systems are we talking about",
+      "are any of those internet facing",
+      "what's the risk if we don't fix them",
+      "help me prioritize which to tackle first"
+    ]
+  },
+  {
+    "id": 10,
+    "title": "Web App Security Review",
+    "category": "Web Application Security",
+    "turns": [
+      "how are our web apps doing from a security standpoint",
+      "which app has the most issues",
+      "what kind of vulns — xss sqli that kind of thing",
+      "are any of these owasp top 10",
+      "what do we tell the dev team"
+    ]
+  },
+  {
+    "id": 11,
+    "title": "TruRisk Score Investigation",
+    "category": "Vulnerability Management",
+    "turns": [
+      "our trurisk score went up this week why",
+      "what changed",
+      "which assets are driving it",
+      "can we do anything about it quickly",
+      "what's the realistic path to getting it back down"
+    ]
+  },
+  {
+    "id": 12,
+    "title": "Threat Intel Briefing",
+    "category": "Threat Intelligence",
+    "turns": [
+      "what threats should we be aware of this week",
+      "tell me more about the active exploit ones",
+      "do we have any of those in our environment",
+      "what's the exposure",
+      "prioritize for me"
+    ]
+  },
+  {
+    "id": 13,
+    "title": "Patch Management Status",
+    "category": "Patch Management",
+    "turns": [
+      "where are we on patching",
+      "what's still open from last month",
+      "which systems are furthest behind",
+      "anything blocking the patches from deploying",
+      "give me a status i can send to the vp"
+    ]
+  },
+  {
+    "id": 14,
+    "title": "Scanner Health Check",
+    "category": "Asset Management",
+    "turns": [
+      "are all our scanners working",
+      "which ones are having issues",
+      "when did those last successfully scan",
+      "how much of our environment is missing coverage",
+      "what do we need to fix"
+    ]
+  },
+  {
+    "id": 15,
+    "title": "SOC Analyst Morning Triage",
+    "category": "Vulnerability Management",
+    "turns": [
+      "morning, what do i need to look at today",
+      "tell me about the top one",
+      "has this been seen before in our environment",
+      "what's the blast radius",
+      "what's the recommended action"
+    ]
+  },
+  {
+    "id": 16,
+    "title": "Executive Vulnerability Briefing",
+    "category": "Vulnerability Management",
+    "turns": [
+      "i need to brief the cto in an hour on our vulnerability posture",
+      "what's our overall risk score",
+      "how do we compare to last quarter",
+      "what are the top 3 things we're doing about it",
+      "any active threats we're exposed to right now"
+    ]
+  },
+  {
+    "id": 17,
+    "title": "Incident: Suspicious Activity on a Host",
+    "category": "Asset Management",
+    "turns": [
+      "we got an alert on 10.20.5.44 what do we know about it",
+      "what vulns does that host have",
+      "any with active exploits",
+      "has there been any fim or edr activity on it",
+      "what's the full risk profile"
+    ]
+  },
+  {
+    "id": 18,
+    "title": "ECS/K8s Container Investigation",
+    "category": "Container Security",
+    "turns": [
+      "what containers are running right now",
+      "any running with known critical vulns",
+      "which namespaces are those in",
+      "are any running as root or privileged",
+      "what's the worst offender"
+    ]
+  },
+  {
+    "id": 19,
+    "title": "Software-Specific Vuln Hunt",
+    "category": "Vulnerability Management",
+    "turns": [
+      "do we have any log4j in our environment",
+      "which versions",
+      "how many hosts",
+      "are any of those hosts internet facing",
+      "what's the patch status"
+    ]
+  },
+  {
+    "id": 20,
+    "title": "Certificate Expiry Review",
+    "category": "Asset Management",
+    "turns": [
+      "any certs expiring soon",
+      "which ones are critical",
+      "what systems are they on",
+      "who do i talk to about renewing them",
+      "are any already expired"
+    ]
+  },
+  {
+    "id": 21,
+    "title": "Vulnerability Exception Review",
+    "category": "Vulnerability Management",
+    "turns": [
+      "what exceptions do we have approved right now",
+      "any expiring soon",
+      "which ones should we reconsider",
+      "are any of the excepted vulns now being actively exploited"
+    ]
+  },
+  {
+    "id": 22,
+    "title": "Eliminate/Mitigation Status",
+    "category": "Patch Management",
+    "turns": [
+      "what's the status of our eliminate program",
+      "how many vulns have we mitigated without patching",
+      "any failed jobs",
+      "what's the risk reduction so far",
+      "what should we prioritize next"
+    ]
+  },
+  {
+    "id": 23,
+    "title": "Risk by Business Unit",
+    "category": "Asset Management",
+    "turns": [
+      "which of our asset groups is riskiest",
+      "tell me more about the production group",
+      "what are the top vulns there",
+      "how long have they been open",
+      "who owns remediation"
+    ]
+  },
+  {
+    "id": 24,
+    "title": "New Employee Security Orientation",
+    "category": "General",
+    "turns": [
+      "hey i just joined the security team, give me an overview of our posture",
+      "what should i focus on first",
+      "what tools do we have connected",
+      "where are the biggest gaps",
+      "what does a typical week look like"
+    ]
+  },
+  {
+    "id": 25,
+    "title": "Post-Incident Review",
+    "category": "Vulnerability Management",
+    "turns": [
+      "we just had an incident on a windows server, what's our overall windows vuln exposure",
+      "how many windows servers do we have total",
+      "which have the most unpatched criticals",
+      "are we missing scan coverage anywhere",
+      "what would a hardening plan look like"
+    ]
+  }
+]

--- a/eval/judge.py
+++ b/eval/judge.py
@@ -9,6 +9,15 @@ from .runner import MODEL
 
 SCORE_WEIGHTS = {"correct": 1.0, "partial": 0.5, "wrong": 0.0, "tool-error": 0.0}
 
+CONV_SCORE_WEIGHTS = {
+    "correct": 1.0,
+    "partial": 0.5,
+    "wrong": 0.0,
+    "tool-error": 0.0,
+    "context-miss": 0.5,
+    "off-track": 0.0,
+}
+
 JUDGE_SYSTEM = """You are a strict but fair evaluator of security tool responses.
 
 You will receive:
@@ -62,6 +71,75 @@ def judge_response(
             parsed = json.loads(json_match.group())
             score = parsed.get("score", "wrong")
             if score not in SCORE_WEIGHTS:
+                score = "wrong"
+            return {"score": score, "reasoning": parsed.get("reasoning", "")}
+        except json.JSONDecodeError:
+            pass
+
+    return {"score": "wrong", "reasoning": f"Judge returned unparseable response: {text[:200]}"}
+
+
+CONV_JUDGE_SYSTEM = """You are a strict but fair evaluator of multi-turn security tool conversations.
+
+You will receive:
+1. The conversation history so far (previous turns and responses)
+2. The current turn's user message
+3. The tool calls made for this turn (if any)
+4. The assistant's response for this turn
+
+Score this turn using EXACTLY one of these labels:
+- "correct": The response correctly answered the question using appropriate tools or conversation context.
+- "partial": The response partially addressed the question, or used incomplete data.
+- "wrong": The wrong tool was called, or the answer missed the point entirely.
+- "tool-error": A tool raised an exception, returned an error, or no tool was called when one should have been.
+- "context-miss": The assistant re-called a tool to fetch data that was ALREADY available in the conversation history. The answer itself may be fine, but the redundant tool call wastes resources.
+- "off-track": The response ignored the conversational context or went on a tangent unrelated to what the user was asking about.
+
+Important: For follow-up questions that reference prior context (e.g., "which of those", "tell me more", "any of these"), the assistant should use data already in the conversation when possible, not re-fetch it.
+
+Respond with JSON only:
+{"score": "<label>", "reasoning": "<1-2 sentence explanation>"}"""
+
+
+def judge_conversation_turn(
+    client: anthropic.Anthropic,
+    conversation_history: str,
+    current_question: str,
+    tool_calls: list[dict],
+    response: str,
+) -> dict:
+    """Use Claude-as-judge to score a single turn within a conversation.
+
+    Returns {"score": str, "reasoning": str}.
+    """
+    tool_calls_text = json.dumps(tool_calls, indent=2) if tool_calls else "No tool calls made."
+
+    user_msg = f"""## Conversation History
+{conversation_history}
+
+## Current Turn Question
+{current_question}
+
+## Tool Calls (this turn)
+{tool_calls_text}
+
+## Assistant Response (this turn)
+{response}"""
+
+    resp = client.messages.create(
+        model=MODEL,
+        max_tokens=256,
+        system=CONV_JUDGE_SYSTEM,
+        messages=[{"role": "user", "content": user_msg}],
+    )
+
+    text = resp.content[0].text.strip()
+    json_match = re.search(r"\{[^}]+\}", text)
+    if json_match:
+        try:
+            parsed = json.loads(json_match.group())
+            score = parsed.get("score", "wrong")
+            if score not in CONV_SCORE_WEIGHTS:
                 score = "wrong"
             return {"score": score, "reasoning": parsed.get("reasoning", "")}
         except json.JSONDecodeError:

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -128,6 +128,101 @@ async def run_question(
     return {"response": assistant_text, "tool_calls": tool_calls_log}
 
 
+async def run_conversation(
+    client: anthropic.Anthropic,
+    session: ClientSession,
+    tools: list[dict],
+    turns: list[str],
+) -> list[dict]:
+    """Run a multi-turn conversation, maintaining message history across turns.
+
+    Returns a list of per-turn results:
+        [{"turn": int, "question": str, "response": str, "tool_calls": list[dict]}, ...]
+    """
+    messages: list[dict] = []
+    turn_results = []
+
+    for turn_idx, user_msg in enumerate(turns, start=1):
+        messages.append({"role": "user", "content": user_msg})
+        tool_calls_log = []
+        assistant_text = ""
+
+        for _ in range(10):  # max iterations per turn
+            resp = client.messages.create(
+                model=MODEL,
+                max_tokens=4096,
+                system=SYSTEM_PROMPT,
+                tools=tools,
+                messages=messages,
+            )
+
+            assistant_text = ""
+            tool_use_blocks = []
+            for block in resp.content:
+                if block.type == "text":
+                    assistant_text += block.text
+                elif block.type == "tool_use":
+                    tool_use_blocks.append(block)
+
+            messages.append({"role": "assistant", "content": resp.content})
+
+            if resp.stop_reason == "end_turn" or not tool_use_blocks:
+                break
+
+            # Process tool calls
+            tool_results = []
+            for block in tool_use_blocks:
+                try:
+                    result_text = await call_mcp_tool(
+                        session, block.name, block.input
+                    )
+                    tool_calls_log.append(
+                        {
+                            "tool": block.name,
+                            "input": block.input,
+                            "output_preview": result_text[:500],
+                            "error": None,
+                        }
+                    )
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": result_text,
+                        }
+                    )
+                except Exception as e:
+                    tool_calls_log.append(
+                        {
+                            "tool": block.name,
+                            "input": block.input,
+                            "output_preview": None,
+                            "error": str(e),
+                        }
+                    )
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": f"Error: {e}",
+                            "is_error": True,
+                        }
+                    )
+
+            messages.append({"role": "user", "content": tool_results})
+
+        turn_results.append(
+            {
+                "turn": turn_idx,
+                "question": user_msg,
+                "response": assistant_text,
+                "tool_calls": tool_calls_log,
+            }
+        )
+
+    return turn_results
+
+
 def get_server_params() -> StdioServerParameters:
     """Build MCP server parameters from environment."""
     return StdioServerParameters(


### PR DESCRIPTION
## Summary
- Add `eval/conversations.json` with 25 multi-turn conversation scenarios (3-6 turns each) written as realistic human conversations
- Add `run_conversation()` to `eval/runner.py` that maintains full message history across turns
- Add `judge_conversation_turn()` to `eval/judge.py` with conversation-aware scoring including new tags: `context-miss` (redundant re-fetch) and `off-track`
- Add `--conversations` CLI flag to `eval/__main__.py` with per-scenario and aggregate reporting
- Results saved to `eval_results/conv_*.json` alongside single-question results
- Conversations run sequentially; existing single-question eval untouched

## Test plan
- [ ] `python -m eval --conversations` runs all 25 scenarios against live MCP
- [ ] `python -m eval --conversations --limit 3` runs first 3 scenarios
- [ ] Score report shows per-turn, per-scenario, and aggregate breakdown
- [ ] Results file is saved to `eval_results/conv_*.json`
- [ ] Existing `python -m eval` still works unchanged

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)