### PR TITLE
fix: guard _run_concurrent against empty task list (#112)

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -1214,6 +1214,8 @@ def _run_concurrent(**tasks):
     """Run named tasks concurrently. Returns dict of {name: result}.
     Each task value is a callable (lambda or function).
     """
+    if not tasks:
+        return {}
     results = {}
     with ThreadPoolExecutor(max_workers=min(len(tasks), 8)) as executor:
         futures = {executor.submit(fn): name for name, fn in tasks.items()}
@@ -3770,6 +3772,10 @@ def get_cloud_risk(limit: int = 20, include_threats: bool = True, days: int = 7)
             first_accounts[provider] = first_acc
 
     result['stats']['total'] = len(result['accounts'])
+
+    if not result['accounts']:
+        result['message'] = 'No cloud connectors configured. Connect AWS, Azure, or GCP accounts in Qualys TotalCloud to see cloud risk data.'
+        return compact(result)
 
     # Fetch evaluations for first account of each provider AND CDR in parallel
     eval_tasks = {


### PR DESCRIPTION
## Summary
- Add `if not tasks: return {}` early-return guard in `_run_concurrent()` to prevent `ValueError` when `ThreadPoolExecutor` is called with `max_workers=0`
- Add early return in `get_cloud_risk()` when no cloud connectors are configured, returning a friendly `message` field instead of silently returning an empty dict

## Root cause
`_run_concurrent()` calls `ThreadPoolExecutor(max_workers=min(len(tasks), 8))`. When `tasks` is empty, `min(0, 8) == 0` raises `ValueError: max_workers must be greater than 0`.

This is triggered in `get_cloud_risk()` when `include_threats=False` and no cloud connectors are configured (empty `eval_tasks` dict).

## Test plan
- [ ] Call `get_cloud_risk(include_threats=False)` with no cloud connectors — should return `{'message': 'No cloud connectors configured...', 'stats': {'total': 0, ...}}` without crashing
- [ ] Call `get_cloud_risk()` (default `include_threats=True`) with no connectors — same friendly message, no crash
- [ ] Call `get_cloud_risk()` with connectors present — unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)