### PR TITLE
fix: remove stale days/cutoff block in fetch_all_eol causing NameError (#114)

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -1137,10 +1137,6 @@ def fetch_all_eol(eol_type, limit=0, max_pages=0, cutoff_date=None):
     if cutoff_date:
         filters.append({"field": "asset.lastUpdatedDate", "operator": "GREATER", "value": cutoff_date})
 
-    if days > 0:
-        cutoff = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%dT00:00:00Z')
-        filters.append({"field": "asset.lastUpdatedDate", "operator": "GREATER", "value": cutoff})
-
     results = []
     seen = set()
     last_id = None


### PR DESCRIPTION
Addresses issue #114

## Root cause
A stale 4-line block was left in `fetch_all_eol` from a merge conflict during the #104 PR. It referenced `days` and `cutoff` — variables that don't exist in `fetch_all_eol`'s scope — causing `NameError: name 'days' is not defined` whenever `os_eol`/`hw_eol` concurrent tasks ran.

The correct date filter is already applied via the `cutoff_date` parameter (set by `get_tech_debt` before dispatch). The duplicate block is simply removed.