### PR TITLE
fix: add CSAM semaphore and increase retry cap for 429 rate limiting (#115)

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -22,7 +22,9 @@ mcp = FastMCP("qualys-mcp")
 
 RETRY_STATUS = {429, 503, 502}
 MAX_RETRIES = 4
-_CSAM_SEM = Semaphore(3)
+CSAM_MAX_RETRIES = int(os.environ.get("CSAM_MAX_RETRIES", "6"))
+# Cap concurrent CSAM requests to avoid 429 floods at high worker concurrency
+_CSAM_SEM = Semaphore(int(os.environ.get("CSAM_MAX_CONCURRENT", "3")))
 _CSAM_COUNT_CACHE = {}
 _CSAM_COUNT_CACHE_TTL = 300
 
@@ -633,7 +635,7 @@ def _scope_filters(base_filters, tag='', asset_group=''):
 def _csam_request(url, body, timeout=30):
     """POST to a CSAM endpoint with retry logic for 429/503/502."""
     token = get_bearer_token()
-    for attempt in range(MAX_RETRIES):
+    for attempt in range(CSAM_MAX_RETRIES):
         req = Request(url, data=body.encode(), method='POST')
         req.add_header('Authorization', f'Bearer {token}' if token else f'Basic {BASIC_AUTH}')
         req.add_header('Content-Type', 'application/json')
@@ -643,7 +645,7 @@ def _csam_request(url, body, timeout=30):
             with _open(req, timeout=timeout) as resp:
                 return json.loads(resp.read())
         except HTTPError as e:
-            if e.code in RETRY_STATUS and attempt < MAX_RETRIES - 1:
+            if e.code in RETRY_STATUS and attempt < CSAM_MAX_RETRIES - 1:
                 retry_after = e.headers.get('Retry-After') if e.headers else None
                 if retry_after:
                     try:
@@ -652,7 +654,7 @@ def _csam_request(url, body, timeout=30):
                         delay = 2 ** attempt + random.uniform(0, 1)
                 else:
                     delay = 2 ** attempt + random.uniform(0, 1)
-                _log(f"CSAM retry {attempt + 1}/{MAX_RETRIES} after {e.code} (wait {delay:.1f}s)")
+                _log(f"CSAM retry {attempt + 1}/{CSAM_MAX_RETRIES} after {e.code} (wait {delay:.1f}s)")
                 time.sleep(delay)
                 continue
             _log(f"csam_search error: HTTP Error {e.code}: {e.reason}")


### PR DESCRIPTION
Addresses issue #115

## Changes

- **CSAM semaphore** (): was already gating concurrent CSAM calls at value 3 — now configurable via `CSAM_MAX_CONCURRENT` env var (default: 3). At concurrency=8, only 3 workers hit CSAM simultaneously.
- **Retry count** increased from 4 → 6 (configurable via `CSAM_MAX_RETRIES` env var). Max backoff reaches ~32s + jitter, giving the API time to recover.
- `_csam_request()` now uses `CSAM_MAX_RETRIES` instead of the shared `MAX_RETRIES` constant so tuning CSAM doesn't affect other APIs.

## Result
At concurrency=8, CSAM requests are serialized to ≤3 concurrent, and if 429s still occur there are now 6 retries to recover — should eliminate the tool-error failures seen in the issue.