### PR TITLE
feat: make eval model configurable via env var (#119)

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -19,6 +19,14 @@ export QUALYS_PASSWORD=...
 export QUALYS_BASE_URL=...
 export ANTHROPIC_API_KEY=...
 
+# Optional: override models (default: claude-haiku-3-5-20241022)
+export EVAL_MODEL=claude-sonnet-4-20250514          # set both runner and judge
+export EVAL_RUNNER_MODEL=claude-sonnet-4-20250514   # runner only (overrides EVAL_MODEL)
+export EVAL_JUDGE_MODEL=claude-haiku-3-5-20241022   # judge only (overrides EVAL_MODEL)
+
+# Optional: route requests through a proxy / OpenRouter
+export ANTHROPIC_BASE_URL=https://openrouter.ai/api/v1
+
 # Run all 500 questions
 python -m eval
 
@@ -58,6 +66,16 @@ Results are saved to `eval_results/YYYY-MM-DD_HHMMSS.json` with:
 | tool-error | 0.0 | Tool exception, error, or no tool called when one should have been |
 
 Overall score = (correct + 0.5 * partial) / total
+
+## Cost guidance
+
+| Model | ~500 questions | ~20 questions (--quick) |
+|-------|---------------|------------------------|
+| Haiku 3.5 (default) | ~$5 | ~$0.20 |
+| Sonnet 4 | ~$50 | ~$2 |
+| Opus 4 | ~$100+ | ~$5 |
+
+Use `--quick` for smoke tests and Haiku for routine runs. Set `EVAL_RUNNER_MODEL` to a larger model only when you need higher-fidelity answers.
 
 ## CI Integration
 

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -28,7 +28,7 @@ from .reporter import (
     print_summary,
     save_results,
 )
-from .runner import MODEL, get_mcp_tools, get_server_params, run_conversation, run_question
+from .runner import JUDGE_MODEL, RUNNER_MODEL, get_mcp_tools, get_server_params, run_conversation, run_question
 from .updater import update_questions_file
 
 
@@ -57,6 +57,8 @@ async def run_eval(args):
     print(f"Eval: {len(questions)} questions (of {total_parsed} total)")
     if args.category:
         print(f"Category filter: {args.category}")
+    print(f"Runner model: {RUNNER_MODEL}")
+    print(f"Judge model:  {JUDGE_MODEL}")
     print(f"Concurrency: {args.concurrency}")
     print(f"Threshold: {args.threshold}")
     print()
@@ -129,7 +131,7 @@ async def run_eval(args):
     summary = compute_summary(results)
     now = datetime.now(timezone.utc)
     run_date = now.strftime("%Y-%m-%d_%H%M%S")
-    result_file = save_results(results, summary, run_date, MODEL)
+    result_file = save_results(results, summary, run_date, RUNNER_MODEL)
     print(f"\nResults saved to {result_file}")
 
     # Print summary
@@ -343,7 +345,8 @@ async def run_conversation_eval(args):
 
     output = {
         "run_date": run_date,
-        "model": MODEL,
+        "runner_model": RUNNER_MODEL,
+        "judge_model": JUDGE_MODEL,
         "type": "conversation",
         "total_scenarios": total_scenarios,
         "total_turns": total_turns,

--- a/eval/judge.py
+++ b/eval/judge.py
@@ -5,7 +5,7 @@ import re
 
 import anthropic
 
-from .runner import MODEL
+from .runner import JUDGE_MODEL
 
 SCORE_WEIGHTS = {"correct": 1.0, "partial": 0.5, "wrong": 0.0, "tool-error": 0.0}
 
@@ -57,7 +57,7 @@ def judge_response(
 {response}"""
 
     resp = client.messages.create(
-        model=MODEL,
+        model=JUDGE_MODEL,
         max_tokens=256,
         system=JUDGE_SYSTEM,
         messages=[{"role": "user", "content": user_msg}],
@@ -127,7 +127,7 @@ def judge_conversation_turn(
 {response}"""
 
     resp = client.messages.create(
-        model=MODEL,
+        model=JUDGE_MODEL,
         max_tokens=256,
         system=CONV_JUDGE_SYSTEM,
         messages=[{"role": "user", "content": user_msg}],

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -8,7 +8,10 @@ import anthropic
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-MODEL = "claude-sonnet-4-20250514"
+_DEFAULT_MODEL = "claude-haiku-3-5-20241022"
+
+RUNNER_MODEL = os.environ.get("EVAL_RUNNER_MODEL") or os.environ.get("EVAL_MODEL") or _DEFAULT_MODEL
+JUDGE_MODEL = os.environ.get("EVAL_JUDGE_MODEL") or os.environ.get("EVAL_MODEL") or _DEFAULT_MODEL
 
 SYSTEM_PROMPT = (
     "You are a security analyst assistant with access to Qualys security tools. "
@@ -62,7 +65,7 @@ async def run_question(
 
     for _ in range(10):  # max iterations
         resp = client.messages.create(
-            model=MODEL,
+            model=RUNNER_MODEL,
             max_tokens=4096,
             system=SYSTEM_PROMPT,
             tools=tools,
@@ -150,7 +153,7 @@ async def run_conversation(
 
         for _ in range(10):  # max iterations per turn
             resp = client.messages.create(
-                model=MODEL,
+                model=RUNNER_MODEL,
                 max_tokens=4096,
                 system=SYSTEM_PROMPT,
                 tools=tools,


### PR DESCRIPTION
Addresses issue #119

## Changes
- Changed default eval model from `claude-sonnet-4-20250514` to `claude-haiku-3-5-20241022` — cuts cost from ~$100 to ~$5 per full 515-question run
- Added `EVAL_MODEL` env var to override both runner and judge model
- Added `EVAL_RUNNER_MODEL` / `EVAL_JUDGE_MODEL` for independent overrides
- Documented `ANTHROPIC_BASE_URL` support (already handled by Anthropic SDK) for proxy/OpenRouter
- Updated `eval/README.md` with env var usage and cost guidance table