### PR TITLE
fix: add global semaphore to serialize CSAM API calls (#122)

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -23,8 +23,8 @@ mcp = FastMCP("qualys-mcp")
 RETRY_STATUS = {429, 503, 502}
 MAX_RETRIES = 4
 CSAM_MAX_RETRIES = int(os.environ.get("CSAM_MAX_RETRIES", "6"))
-# Cap concurrent CSAM requests to avoid 429 floods at high worker concurrency
-_CSAM_SEM = Semaphore(int(os.environ.get("CSAM_MAX_CONCURRENT", "3")))
+# Serialize CSAM requests to avoid 429 thundering-herd at high eval concurrency
+_CSAM_SEM = Semaphore(int(os.environ.get("CSAM_CONCURRENCY", "1")))
 _CSAM_COUNT_CACHE = {}
 _CSAM_COUNT_CACHE_TTL = 300
 


### PR DESCRIPTION
Addresses issue #122

## Problem
Concurrent eval runs (concurrency ≥ 2) caused multiple CSAM API calls to hit 429 simultaneously, then all retry at the same time — thundering herd that never staggers out.

## Fix
- Changed default CSAM concurrency from 3 → 1, serializing all CSAM calls through the existing `threading.Semaphore` + `with _CSAM_SEM:` guards on `csam_count()` and `csam_search()`
- Renamed env var to `CSAM_CONCURRENCY` (was `CSAM_MAX_CONCURRENT`) for clarity
- Set `CSAM_CONCURRENCY=2` if some parallelism is acceptable while still preventing flood

## Acceptance
- Concurrent eval runs no longer produce cascading 429s on CSAM
- At most 1 CSAM request runs at a time by default (configurable)