### PR TITLE
fix: handle empty CSAM response body to prevent JSONDecodeError (#123)

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -643,7 +643,11 @@ def _csam_request(url, body, timeout=30):
         req.add_header('X-Requested-With', 'qualys-mcp')
         try:
             with _open(req, timeout=timeout) as resp:
-                return json.loads(resp.read())
+                raw = resp.read()
+                if not raw or not raw.strip():
+                    _log("[DEBUG] csam_search: empty response body — returning empty result")
+                    return {}
+                return json.loads(raw)
         except HTTPError as e:
             if e.code in RETRY_STATUS and attempt < CSAM_MAX_RETRIES - 1:
                 retry_after = e.headers.get('Retry-After') if e.headers else None


### PR DESCRIPTION
Addresses issue #123

## Problem
`_csam_request()` calls `json.loads(resp.read())` without checking for an empty body. When the Qualys CSAM API returns HTTP 200 with no content, this throws `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.

## Fix
Read the response bytes first, check if empty, and return `{}` (treated as zero results by callers) instead of crashing. The empty-body condition is logged at DEBUG level.

## Behaviour after fix
- Empty CSAM API response → `csam_search` returns `[]` (no crash)
- Log output: `[DEBUG] csam_search: empty response body — returning empty result`