### PR TITLE
fix: respect pagination limits — stop fetching after limit records (#126)

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -706,7 +706,7 @@ def csam_count(filters=None):
         return 0
 
 
-def csam_search(filters=None, limit=100, fields=None, fetch_all=True):
+def csam_search(filters=None, limit=100, fields=None, fetch_all=False):
     """Search assets with optional structured filters. Returns list of assets.
     filters: list of {"field": "...", "operator": "...", "value": "..."} dicts
     fields: comma-separated includeFields (e.g. "operatingSystem,hardware")
@@ -783,7 +783,7 @@ def is_eol_stage(stage):
 
 def _paginate_json(base_url, limit, data_key='data', count_key='count',
                     page_param='pageNumber', size_param='pageSize',
-                    count_only=False, gateway=True, fetch_all=True, not_found_ok=False,
+                    count_only=False, gateway=True, fetch_all=False, not_found_ok=False,
                     page_start=1):
     """Generic paginated fetch for JSON APIs. Returns list or int (count_only).
     When fetch_all=True (default), fetches all pages up to MAX_PAGES (0=unlimited).


### PR DESCRIPTION
Addresses issue #126

## Problem
`_paginate_json()` and `csam_search()` both had `fetch_all=True` as default, causing them to fetch every page regardless of the caller's `limit` parameter. This resulted in:
- AWS connectors: 993 records fetched when limit=5
- CSAM assets: 7300–9000+ assets per call
- Container images: 384 records fetched when limit=50

## Fix
Two-line change in `qualys_mcp.py`:
- `_paginate_json()`: `fetch_all=True` → `fetch_all=False`
- `csam_search()`: `fetch_all=True` → `fetch_all=False`

Both functions already had early-stop logic (page cap = `ceil(limit / page_size)`) — the default was just wrong. Callers that genuinely need all records (e.g. `fetch_all_eol`) have their own pagination loops and are unaffected.

## Expected outcome
- Simple questions answer in seconds instead of 30–120s
- CSAM 429 rate limiting significantly reduced
- No tool fetches more than its declared `limit` records for summary-type calls