### PR TITLE
fix: handle CDR findings 500 error with graceful fallback (#125)

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -26,6 +26,7 @@ MAX_RETRIES = 4
 KB_CONFLICT_MAX_RETRIES = 3
 KB_CONFLICT_BASE_DELAY = 3  # seconds
 KB_BUSY_MSG = "Knowledge base export is currently busy (concurrent request in progress). Please try again in a moment."
+CDR_UNAVAILABLE_MSG = "CDR findings currently unavailable"
 CSAM_MAX_RETRIES = int(os.environ.get("CSAM_MAX_RETRIES", "6"))
 # Cap concurrent CSAM requests to avoid 429 floods at high worker concurrency
 _CSAM_SEM = Semaphore(int(os.environ.get("CSAM_MAX_CONCURRENT", "3")))
@@ -294,6 +295,9 @@ def api_get(url, gateway=False, timeout=30, not_found_ok=False):
             if e.code in KB_CONFLICT_RETRY_STATUS:
                 _log(f"KB busy (409 conflict) after {KB_CONFLICT_MAX_RETRIES} retries: {url.split('?')[0]}")
                 return 'KB_BUSY'
+            if e.code == 500 and '/cdr-api/' in url:
+                _log(f"[WARN] CDR findings endpoint returned 500 — treating as temporarily unavailable: {url.split('?')[0]}")
+                return 'CDR_UNAVAILABLE'
             _log(f"API error {e.code}: {url.split('?')[0]}")
             return None
         except URLError as e:
@@ -809,6 +813,8 @@ def _paginate_json(base_url, limit, data_key='data', count_key='count',
             break
         url = f"{base_url}{sep}{size_param}={page_size}&{page_param}={page}"
         data = api_get(url, gateway=gateway, not_found_ok=not_found_ok)
+        if data == 'CDR_UNAVAILABLE':
+            return data  # propagate sentinel to caller
         try:
             parsed = json.loads(data) if data else {}
         except json.JSONDecodeError:
@@ -870,8 +876,11 @@ def get_cdr(days=7, limit=100, severity=None, cloud_provider=None, category=None
         url += f"&cloudProvider={cloud_provider}"
     if category:
         url += f"&category={category}"
-    return _paginate_json(url, limit, data_key='content', count_key='totalElements',
-                          page_param='pageNumber', size_param='limit')
+    result = _paginate_json(url, limit, data_key='content', count_key='totalElements',
+                           page_param='pageNumber', size_param='limit')
+    if result == 'CDR_UNAVAILABLE':
+        return {'error': CDR_UNAVAILABLE_MSG, 'findings': []}
+    return result
 
 
 def get_image_details(image_id):
@@ -3829,7 +3838,12 @@ def get_cloud_risk(limit: int = 20, include_threats: bool = True, days: int = 7)
         sev_map = {'1': 'LOW', '2': 'MEDIUM', '3': 'HIGH', '4': 'CRITICAL'}
         by_provider = {}
         by_category = {}
-        findings = eval_results.get('cdr') or []
+        cdr_raw = eval_results.get('cdr') or []
+        if isinstance(cdr_raw, dict) and 'error' in cdr_raw:
+            result['cdrStatus'] = cdr_raw['error']
+            findings = []
+        else:
+            findings = cdr_raw
 
         for f in findings:
             sev = str(f.get('severity', '')).upper()
@@ -4483,7 +4497,12 @@ def get_threats(days: int = 7, limit: int = 50) -> dict:
         })
     result['stats']['edr'] = len(edr_events)
 
-    cdr_findings = concurrent.get('cdr') or []
+    cdr_raw = concurrent.get('cdr') or []
+    if isinstance(cdr_raw, dict) and 'error' in cdr_raw:
+        result['cdrStatus'] = cdr_raw['error']
+        cdr_findings = []
+    else:
+        cdr_findings = cdr_raw
     for f in cdr_findings:
         sev = str(f.get('severity', ''))
         if sev in ['CRITICAL', '5']:


### PR DESCRIPTION
Addresses issue #125

## Changes

- Added CDR_UNAVAILABLE_MSG constant for consistent messaging
- api_get() catches HTTP 500 for /cdr-api/ URLs, logs at WARN level, returns sentinel
- _paginate_json() propagates the sentinel instead of JSON-parsing an error response
- get_cdr() converts sentinel to a clean {error, findings: []} dict
- get_cloud_risk() and get_threats() check for error dict, set cdrStatus, use empty findings list

## Behavior

- CDR 500 no longer crashes the tool or surfaces as an unhandled error
- Tool returns a clean empty/unavailable response: "CDR findings currently unavailable"
- Logged at WARN level (not ERROR) since this may be transient

Follows the same sentinel-value pattern used for KB 409 handling.