### PR TITLE
fix: CDR findings endpoint 500 returns graceful fallback with WARN log

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -189,6 +189,16 @@ def _log(msg):
     print(f"[qualys-mcp] {msg}", file=sys.stderr)
 
 
+def _log_warn(msg):
+    """Log a WARN-level message to stderr (transient/expected conditions, not errors)."""
+    print(f"[qualys-mcp] WARN: {msg}", file=sys.stderr)
+
+
+# Sentinel returned by api_get / _paginate_json to signal a server-side 5xx error
+# (distinct from None which means "no data / not configured").
+_SERVER_UNAVAILABLE = '__SERVER_UNAVAILABLE__'
+
+
 def _get_or_fetch(cache_dict, cache_time_dict, key, fetch_fn, ttl):
     """Thread-safe cache get-or-fetch with in-flight request deduplication.
     If a fetch is already in progress for *key*, subsequent callers wait on a
@@ -259,7 +269,7 @@ def get_bearer_token():
             return None
 
 
-def api_get(url, gateway=False, timeout=30, not_found_ok=False):
+def api_get(url, gateway=False, timeout=30, not_found_ok=False, server_error_ok=False):
     for attempt in range(MAX_RETRIES):
         req = Request(url)
         if gateway:
@@ -291,6 +301,9 @@ def api_get(url, gateway=False, timeout=30, not_found_ok=False):
                 continue
             if e.code == 404 and not_found_ok:
                 return None  # 404 means resource not configured — treat as empty, not an error
+            if e.code == 500 and server_error_ok:
+                _log_warn(f"Server error (500): {url.split('?')[0]} — endpoint may be temporarily unavailable")
+                return _SERVER_UNAVAILABLE
             if e.code in KB_CONFLICT_RETRY_STATUS:
                 _log(f"KB busy (409 conflict) after {KB_CONFLICT_MAX_RETRIES} retries: {url.split('?')[0]}")
                 return 'KB_BUSY'
@@ -784,11 +797,12 @@ def is_eol_stage(stage):
 def _paginate_json(base_url, limit, data_key='data', count_key='count',
                     page_param='pageNumber', size_param='pageSize',
                     count_only=False, gateway=True, fetch_all=True, not_found_ok=False,
-                    page_start=1):
+                    page_start=1, server_error_ok=False):
     """Generic paginated fetch for JSON APIs. Returns list or int (count_only).
     When fetch_all=True (default), fetches all pages up to MAX_PAGES (0=unlimited).
     When fetch_all=False, respects the limit parameter strictly.
-    When not_found_ok=True, a 404 response is treated as empty rather than logged as an error."""
+    When not_found_ok=True, a 404 response is treated as empty rather than logged as an error.
+    When server_error_ok=True, a 500 response returns _SERVER_UNAVAILABLE sentinel instead of None."""
     page_size = min(limit, 100)
     results = []
     page = page_start
@@ -808,7 +822,9 @@ def _paginate_json(base_url, limit, data_key='data', count_key='count',
         if not fetch_all and len(results) >= limit:
             break
         url = f"{base_url}{sep}{size_param}={page_size}&{page_param}={page}"
-        data = api_get(url, gateway=gateway, not_found_ok=not_found_ok)
+        data = api_get(url, gateway=gateway, not_found_ok=not_found_ok, server_error_ok=server_error_ok)
+        if data is _SERVER_UNAVAILABLE:
+            return _SERVER_UNAVAILABLE
         try:
             parsed = json.loads(data) if data else {}
         except json.JSONDecodeError:
@@ -870,8 +886,13 @@ def get_cdr(days=7, limit=100, severity=None, cloud_provider=None, category=None
         url += f"&cloudProvider={cloud_provider}"
     if category:
         url += f"&category={category}"
-    return _paginate_json(url, limit, data_key='content', count_key='totalElements',
-                          page_param='pageNumber', size_param='limit')
+    result = _paginate_json(url, limit, data_key='content', count_key='totalElements',
+                            page_param='pageNumber', size_param='limit',
+                            server_error_ok=True)
+    if result is _SERVER_UNAVAILABLE:
+        _log_warn("CDR findings endpoint returned 500 — returning empty result (transient server issue)")
+        return {'available': False, 'message': 'CDR findings currently unavailable', 'data': []}
+    return result
 
 
 def get_image_details(image_id):
@@ -3829,7 +3850,12 @@ def get_cloud_risk(limit: int = 20, include_threats: bool = True, days: int = 7)
         sev_map = {'1': 'LOW', '2': 'MEDIUM', '3': 'HIGH', '4': 'CRITICAL'}
         by_provider = {}
         by_category = {}
-        findings = eval_results.get('cdr') or []
+        cdr_result = eval_results.get('cdr')
+        if isinstance(cdr_result, dict) and not cdr_result.get('available', True):
+            result.setdefault('warnings', []).append(cdr_result.get('message', 'CDR findings currently unavailable'))
+            findings = []
+        else:
+            findings = cdr_result or []
 
         for f in findings:
             sev = str(f.get('severity', '')).upper()
@@ -4483,7 +4509,12 @@ def get_threats(days: int = 7, limit: int = 50) -> dict:
         })
     result['stats']['edr'] = len(edr_events)
 
-    cdr_findings = concurrent.get('cdr') or []
+    cdr_result = concurrent.get('cdr')
+    if isinstance(cdr_result, dict) and not cdr_result.get('available', True):
+        result.setdefault('warnings', []).append(cdr_result.get('message', 'CDR findings currently unavailable'))
+        cdr_findings = []
+    else:
+        cdr_findings = cdr_result or []
     for f in cdr_findings:
         sev = str(f.get('severity', ''))
         if sev in ['CRITICAL', '5']:


### PR DESCRIPTION
Addresses issue #125

## Changes

- Add _log_warn() helper for WARN-level logging
- Add _SERVER_UNAVAILABLE sentinel to distinguish server errors from empty data
- Add server_error_ok param to api_get: 500 -> WARN log + sentinel instead of ERROR
- Add server_error_ok param to _paginate_json: propagates sentinel to callers
- get_cdr: uses server_error_ok=True, returns {available: False, message: 'CDR findings currently unavailable'} on 500
- get_threats: handles CDR unavailable dict, appends message to warnings field
- get_cloud_risk: same graceful handling for include_threats CDR path

## Acceptance

- CDR 500 logs at WARN level instead of error
- Tool returns clean empty/unavailable response; no unhandled exceptions
- Callers include warnings field so the user knows why CDR data is missing