### PR TITLE
fix: auto-load .env in eval harness

### DIFF
--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -15,6 +15,10 @@ import os
 import sys
 from datetime import datetime, timezone
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 import anthropic
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "fastmcp>=0.1.0",
+    "python-dotenv>=0.19.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #138

## Summary
- Add `python-dotenv` to project dependencies in `pyproject.toml`
- Call `load_dotenv()` at the top of `eval/__main__.py` before env var validation so `python -m eval` works without manually sourcing `.env`

## Test plan
- [ ] Run `python -m eval --quick` without sourcing `.env` first — should pick up vars from `.env` automatically
- [ ] Verify existing behavior is unchanged when env vars are already exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)