### PR TITLE
fix: reduce CSAM concurrency semaphore to prevent 429 storms (#139)

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -29,7 +29,7 @@ KB_BUSY_MSG = "Knowledge base export is currently busy (concurrent request in pr
 CDR_UNAVAILABLE_MSG = "CDR findings currently unavailable"
 CSAM_MAX_RETRIES = int(os.environ.get("CSAM_MAX_RETRIES", "6"))
 # Cap concurrent CSAM requests to avoid 429 floods at high worker concurrency
-_CSAM_SEM = Semaphore(int(os.environ.get("CSAM_MAX_CONCURRENT", "3")))
+_CSAM_SEM = Semaphore(int(os.environ.get("CSAM_MAX_CONCURRENT", "2")))
 _CSAM_COUNT_CACHE = {}
 _CSAM_COUNT_CACHE_TTL = 300
 


### PR DESCRIPTION
## Summary
- Lowers the default `CSAM_MAX_CONCURRENT` semaphore from 3 to 2, reducing parallel CSAM API requests and preventing 429 rate-limit storms under high worker concurrency
- The existing per-request retry logic (exponential backoff with jitter) remains as a fallback
- Still configurable via the `CSAM_MAX_CONCURRENT` environment variable

Closes #139

## Test plan
- [ ] Verify CSAM search/count still works with default concurrency of 2
- [ ] Under high concurrency, confirm 429 responses are reduced compared to the previous default of 3
- [ ] Verify `CSAM_MAX_CONCURRENT` env var override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)