### PR TITLE
fix: auto-load .env in eval harness (#138)

### DIFF
--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -15,6 +15,10 @@ import os
 import sys
 from datetime import datetime, timezone
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 import anthropic
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,13 @@ dependencies = [
     "fastmcp>=0.1.0",
 ]
 
+[project.optional-dependencies]
+eval = [
+    "anthropic",
+    "mcp",
+    "python-dotenv",
+]
+
 [project.urls]
 Homepage = "https://github.com/nelssec/qualys-mcp"
 Repository = "https://github.com/nelssec/qualys-mcp"


### PR DESCRIPTION
Addresses issue #138

## Problem
`eval/__main__.py` validated env vars but never called `load_dotenv()`, so running `python -m eval` from a fresh shell without manually sourcing `.env` caused 497/515 questions to fail with `401 invalid x-api-key`.

## Fix
- Added `from dotenv import load_dotenv` + `load_dotenv()` at the top of `eval/__main__.py`, before env var validation
- Added `python-dotenv` to `[project.optional-dependencies] eval` in `pyproject.toml`