### PR TITLE
fix: global CSAM rate limiter to prevent 429 storms under concurrency (#139)

### DIFF
--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -28,8 +28,10 @@ KB_CONFLICT_BASE_DELAY = 3  # seconds
 KB_BUSY_MSG = "Knowledge base export is currently busy (concurrent request in progress). Please try again in a moment."
 CDR_UNAVAILABLE_MSG = "CDR findings currently unavailable"
 CSAM_MAX_RETRIES = int(os.environ.get("CSAM_MAX_RETRIES", "6"))
-# Cap concurrent CSAM requests to avoid 429 floods at high worker concurrency
-_CSAM_SEM = Semaphore(int(os.environ.get("CSAM_MAX_CONCURRENT", "3")))
+# Serialize CSAM requests by default (semaphore=1) to prevent 429 retry storms
+# when multiple concurrent callers (e.g. eval harness) hit the API simultaneously.
+# Override with CSAM_MAX_CONCURRENT env var if the API can handle more.
+_CSAM_SEM = Semaphore(int(os.environ.get("CSAM_MAX_CONCURRENT", "1")))
 _CSAM_COUNT_CACHE = {}
 _CSAM_COUNT_CACHE_TTL = 300
 


### PR DESCRIPTION
Addresses issue #139

## Summary
The CSAM module already had an asyncio semaphore wrapping both csam_count() and csam_search(), but its default concurrency was set to 3 — high enough that concurrent eval requests still pile up and trigger 429 storms.

## Change
- Reduced CSAM_MAX_CONCURRENT default from 3 to 1 in qualys_mcp.py, serializing CSAM API requests through the existing semaphore
- Users who need higher throughput can still override via the CSAM_MAX_CONCURRENT env var

## Result
Concurrent eval runs (e.g. --concurrency 4) will queue CSAM requests through the semaphore rather than hammering the API in parallel, eliminating the retry-storm feedback loop that caused 30-minute eval runs.