### PR TITLE
feat: persistent disk cache with per-type TTLs (#159)

### DIFF
--- a/qualys/aggregators.py
+++ b/qualys/aggregators.py
@@ -1924,6 +1924,19 @@ def etm_findings(qql: str = "", report_id: str = "", detail: str = "standard") -
             cached['cacheAge'] = int(age)
             return compact(cached)
 
+    # L2 disk cache check for ETM (no qql filter only)
+    if not qql:
+        from qualys.cache import disk_cache, TTL_ETM as DISK_TTL_ETM
+        _ETM_DISK_KEY = "etm_result"
+        disk_hit = disk_cache.get(_ETM_DISK_KEY)
+        if disk_hit is not None:
+            ETM_RESULT_CACHE = disk_hit
+            ETM_RESULT_CACHE_TIME = now
+            _log("Disk cache hit for etm_result")
+            cached = dict(disk_hit)
+            cached['cacheAge'] = 0
+            return compact(cached)
+
     all_dets = []
     for sev in severities:
         dets = get_detections(severity=sev, days=30)
@@ -1960,6 +1973,8 @@ def etm_findings(qql: str = "", report_id: str = "", detail: str = "standard") -
     if not qql:
         ETM_RESULT_CACHE = formatted
         ETM_RESULT_CACHE_TIME = now
+        from qualys.cache import disk_cache, TTL_ETM as DISK_TTL_ETM
+        disk_cache.set("etm_result", formatted, DISK_TTL_ETM)
 
     result = _with_meta(formatted, 'findings', formatted.get('totalFindings', len(formatted.get('findings', []))))
     return _apply_detail_level(result, detail, list_keys=['findings', 'topCVEs'])
@@ -4269,6 +4284,8 @@ def summarize_investigation_agg(findings: str, audience: str = "technical") -> s
 
 def cache_status_agg(clear: bool = False) -> dict:
     """Show cache stats or clear all caches."""
+    from qualys.cache import disk_cache, DB_PATH
+    from qualys.api import clear_memory_cache
     global ETM_RESULT_CACHE, ETM_RESULT_CACHE_TIME
     global SCANNER_CACHE, SCANNER_CACHE_TIME
 
@@ -4284,7 +4301,14 @@ def cache_status_agg(clear: bool = False) -> dict:
         'etm_result_cached': ETM_RESULT_CACHE is not None,
         'etm_cache_age_seconds': None,
         'bearer_token_age_seconds': None,
+        'disk_cache_path': str(DB_PATH),
+        'disk_cache_size_kb': disk_cache.size_kb(),
     }
+
+    # Disk age per cached key
+    disk_keys = disk_cache.keys()
+    if disk_keys:
+        result['disk_age_s'] = {k: disk_cache.age(k) for k in disk_keys}
 
     if DETECTION_CACHE_TIME:
         newest = max(DETECTION_CACHE_TIME.values())
@@ -4297,17 +4321,8 @@ def cache_status_agg(clear: bool = False) -> dict:
         result['etm_cache_age_seconds'] = int((now - ETM_RESULT_CACHE_TIME).total_seconds())
 
     if clear:
-        KB_CACHE.clear()
-        KB_CACHE_TIME.clear()
-        DETECTION_CACHE.clear()
-        DETECTION_CACHE_TIME.clear()
-        QDS_CACHE.clear()
-        WAS_CACHE.clear()
-        WAS_CACHE_TIME.clear()
-        SCANNER_CACHE = None
-        SCANNER_CACHE_TIME = None
-        ETM_RESULT_CACHE = None
-        ETM_RESULT_CACHE_TIME = None
+        clear_memory_cache()
+        disk_cache.clear()
         result['cleared'] = True
         result['kb_entries'] = 0
         result['detection_entries'] = 0
@@ -4318,6 +4333,8 @@ def cache_status_agg(clear: bool = False) -> dict:
         result['cache_age_s'] = None
         result['scanner_cache_age_seconds'] = None
         result['etm_cache_age_seconds'] = None
+        result['disk_cache_size_kb'] = 0
+        result.pop('disk_age_s', None)
 
     result['_meta'] = {'returned': 1, 'total': 1, 'truncated': False}
     return compact(result)

--- a/qualys/api.py
+++ b/qualys/api.py
@@ -18,6 +18,14 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock, Thread, Event, Semaphore
+from qualys.cache import (
+    disk_cache,
+    TTL_VMDR as DISK_TTL_VMDR,
+    TTL_WAS as DISK_TTL_WAS,
+    TTL_SCANNERS as DISK_TTL_SCANNERS,
+    TTL_ETM as DISK_TTL_ETM,
+    TTL_CSAM as DISK_TTL_CSAM,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -251,14 +259,26 @@ def _log(msg):
 # ---------------------------------------------------------------------------
 
 
-def _get_or_fetch(cache_dict, cache_time_dict, key, fetch_fn, ttl):
+def _get_or_fetch(cache_dict, cache_time_dict, key, fetch_fn, ttl, disk_ttl=None):
     """Thread-safe cache get-or-fetch with in-flight request deduplication.
     If a fetch is already in progress for *key*, subsequent callers wait on a
-    threading.Event instead of issuing a duplicate API call."""
+    threading.Event instead of issuing a duplicate API call.
+
+    When *disk_ttl* is set, the SQLite L2 cache is checked on L1 miss and
+    written after a successful fetch."""
     now = datetime.now(timezone.utc)
     cached_time = cache_time_dict.get(key)
     if key in cache_dict and cached_time and (now - cached_time).total_seconds() < ttl:
         return cache_dict[key]
+
+    # L2 disk cache check (before acquiring inflight lock)
+    if disk_ttl is not None:
+        disk_hit = disk_cache.get(key)
+        if disk_hit is not None:
+            cache_dict[key] = disk_hit
+            cache_time_dict[key] = datetime.now(timezone.utc)
+            _log(f"Disk cache hit for {key}")
+            return disk_hit
 
     with _inflight_lock:
         # Re-check cache inside lock (another thread may have just finished)
@@ -283,11 +303,37 @@ def _get_or_fetch(cache_dict, cache_time_dict, key, fetch_fn, ttl):
         result = fetch_fn()
         cache_dict[key] = result
         cache_time_dict[key] = datetime.now(timezone.utc)
+        if disk_ttl is not None:
+            disk_cache.set(key, result, disk_ttl)
         return result
     finally:
         with _inflight_lock:
             _inflight.pop(key, None)
         evt.set()  # wake up any waiters
+
+
+def clear_memory_cache(key=None):
+    """Clear in-memory L1 caches. If *key* is given, clear only that key."""
+    global SCANNER_CACHE, SCANNER_CACHE_TIME, ETM_RESULT_CACHE, ETM_RESULT_CACHE_TIME
+    if key:
+        DETECTION_CACHE.pop(key, None)
+        DETECTION_CACHE_TIME.pop(key, None)
+        KB_CACHE.pop(key, None)
+        KB_CACHE_TIME.pop(key, None)
+        WAS_CACHE.pop(key, None)
+        WAS_CACHE_TIME.pop(key, None)
+    else:
+        DETECTION_CACHE.clear()
+        DETECTION_CACHE_TIME.clear()
+        KB_CACHE.clear()
+        KB_CACHE_TIME.clear()
+        WAS_CACHE.clear()
+        WAS_CACHE_TIME.clear()
+        QDS_CACHE.clear()
+        SCANNER_CACHE = None
+        SCANNER_CACHE_TIME = None
+        ETM_RESULT_CACHE = None
+        ETM_RESULT_CACHE_TIME = None
 
 
 # ---------------------------------------------------------------------------
@@ -574,9 +620,10 @@ def get_detections(severity=5, limit=0, use_cache=True, days=30, qds_min=0, fetc
         result = _fetch()
         DETECTION_CACHE[cache_key] = result
         DETECTION_CACHE_TIME[cache_key] = datetime.now(timezone.utc)
+        disk_cache.set(cache_key, result, DISK_TTL_VMDR)
         return result[:limit] if limit > 0 else result
 
-    dets = _get_or_fetch(DETECTION_CACHE, DETECTION_CACHE_TIME, cache_key, _fetch, VMDR_CACHE_TTL)
+    dets = _get_or_fetch(DETECTION_CACHE, DETECTION_CACHE_TIME, cache_key, _fetch, VMDR_CACHE_TTL, disk_ttl=DISK_TTL_VMDR)
     return dets[:limit] if limit > 0 else dets
 
 
@@ -1122,7 +1169,7 @@ def get_was_findings(limit=100, severity=None, days=None, app_name=None):
             _log(f"WAS findings error: {e}")
             return []
 
-    return _get_or_fetch(WAS_CACHE, WAS_CACHE_TIME, cache_key, _fetch, 600)
+    return _get_or_fetch(WAS_CACHE, WAS_CACHE_TIME, cache_key, _fetch, 600, disk_ttl=DISK_TTL_WAS)
 
 
 # ---------------------------------------------------------------------------
@@ -1201,7 +1248,7 @@ def get_mtg_job_detail(job_id):
 
 
 def get_scanner_list():
-    """Get scanner appliance list with status and health metrics. Uses 5-minute cache."""
+    """Get scanner appliance list with status and health metrics. Uses 5-minute L1 / 12-hour disk cache."""
     global SCANNER_CACHE, SCANNER_CACHE_TIME
     now = datetime.now(timezone.utc)
 
@@ -1209,6 +1256,15 @@ def get_scanner_list():
         age = (now - SCANNER_CACHE_TIME).total_seconds()
         if age < 300:
             return SCANNER_CACHE
+
+    # L2 disk cache check
+    _SCANNER_DISK_KEY = "scanner_list"
+    disk_hit = disk_cache.get(_SCANNER_DISK_KEY)
+    if disk_hit is not None:
+        SCANNER_CACHE = disk_hit
+        SCANNER_CACHE_TIME = now
+        _log("Disk cache hit for scanner_list")
+        return SCANNER_CACHE
 
     data = api_get(f"{BASE_URL}/api/2.0/fo/appliance/?action=list&output_mode=full", timeout=30)
     if not data:
@@ -1238,6 +1294,7 @@ def get_scanner_list():
         pass
     SCANNER_CACHE = scanners
     SCANNER_CACHE_TIME = now
+    disk_cache.set("scanner_list", scanners, DISK_TTL_SCANNERS)
     return scanners
 
 
@@ -1385,6 +1442,13 @@ def _warmup_vmdr_cache():
     time.sleep(2)  # brief delay to let server finish startup
     for sev in (5, 4, 3):
         try:
+            cache_key = f"detections_{sev}_30_0"
+            disk_hit = disk_cache.get(cache_key)
+            if disk_hit is not None:
+                DETECTION_CACHE[cache_key] = disk_hit
+                DETECTION_CACHE_TIME[cache_key] = datetime.now(timezone.utc)
+                _log(f"Disk cache hit during warmup for {cache_key}")
+                continue
             _log(f"Cache warm-up: fetching severity {sev} detections...")
             get_detections(severity=sev, use_cache=False)
             _log(f"Cache warm-up: severity {sev} done")

--- a/qualys/cache.py
+++ b/qualys/cache.py
@@ -1,0 +1,150 @@
+"""SQLite-backed L2 disk cache with per-type TTLs."""
+
+import os
+import pickle
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Cache directory & DB path
+# ---------------------------------------------------------------------------
+
+CACHE_DIR = Path(os.environ.get("QUALYS_MCP_CACHE_DIR", Path.home() / ".cache" / "qualys-mcp"))
+DB_PATH = CACHE_DIR / "cache.db"
+
+# ---------------------------------------------------------------------------
+# Per-type TTL constants (seconds), each overridable via env var
+# ---------------------------------------------------------------------------
+
+TTL_VMDR = int(os.environ.get("CACHE_TTL_VMDR", 4 * 3600))
+TTL_CSAM = int(os.environ.get("CACHE_TTL_CSAM", 6 * 3600))
+TTL_CERTS = int(os.environ.get("CACHE_TTL_CERTS", 12 * 3600))
+TTL_CLOUD = int(os.environ.get("CACHE_TTL_CLOUD", 6 * 3600))
+TTL_PATCH = int(os.environ.get("CACHE_TTL_PATCH", 1 * 3600))
+TTL_SCANNERS = int(os.environ.get("CACHE_TTL_SCANNERS", 12 * 3600))
+TTL_WAS = int(os.environ.get("CACHE_TTL_WAS", 4 * 3600))
+TTL_ETM = int(os.environ.get("CACHE_TTL_ETM", 2 * 3600))
+TTL_CONTAINERS = int(os.environ.get("CACHE_TTL_CONTAINERS", 6 * 3600))
+TTL_DEFAULT = int(os.environ.get("CACHE_TTL_DEFAULT", 4 * 3600))
+
+
+# ---------------------------------------------------------------------------
+# DiskCache
+# ---------------------------------------------------------------------------
+
+class DiskCache:
+    """Thread-safe SQLite-backed cache. All errors are caught and logged."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._conn = None
+        try:
+            CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(str(DB_PATH), check_same_thread=False)
+            self._conn.execute(
+                "CREATE TABLE IF NOT EXISTS cache "
+                "(key TEXT PRIMARY KEY, value BLOB, fetched_at REAL, ttl INTEGER)"
+            )
+            self._conn.commit()
+        except sqlite3.Error as exc:
+            import sys
+            print(f"[qualys-mcp] DiskCache init warning: {exc}", file=sys.stderr)
+
+    def get(self, key):
+        """Return unpickled value if not expired, else None."""
+        with self._lock:
+            try:
+                if self._conn is None:
+                    return None
+                row = self._conn.execute(
+                    "SELECT value, fetched_at, ttl FROM cache WHERE key = ?", (key,)
+                ).fetchone()
+                if row is None:
+                    return None
+                value_blob, fetched_at, ttl = row
+                if time.time() - fetched_at > ttl:
+                    return None
+                return pickle.loads(value_blob)
+            except Exception as exc:
+                import sys
+                print(f"[qualys-mcp] DiskCache.get warning: {exc}", file=sys.stderr)
+                return None
+
+    def set(self, key, value, ttl):
+        """Pickle value and upsert into cache."""
+        with self._lock:
+            try:
+                if self._conn is None:
+                    return
+                blob = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO cache (key, value, fetched_at, ttl) VALUES (?, ?, ?, ?)",
+                    (key, blob, time.time(), ttl),
+                )
+                self._conn.commit()
+            except Exception as exc:
+                import sys
+                print(f"[qualys-mcp] DiskCache.set warning: {exc}", file=sys.stderr)
+
+    def clear(self, key=None):
+        """Delete specific key or all rows."""
+        with self._lock:
+            try:
+                if self._conn is None:
+                    return
+                if key:
+                    self._conn.execute("DELETE FROM cache WHERE key = ?", (key,))
+                else:
+                    self._conn.execute("DELETE FROM cache")
+                self._conn.commit()
+            except Exception as exc:
+                import sys
+                print(f"[qualys-mcp] DiskCache.clear warning: {exc}", file=sys.stderr)
+
+    def age(self, key):
+        """Seconds since fetched_at, or None if missing/expired."""
+        with self._lock:
+            try:
+                if self._conn is None:
+                    return None
+                row = self._conn.execute(
+                    "SELECT fetched_at, ttl FROM cache WHERE key = ?", (key,)
+                ).fetchone()
+                if row is None:
+                    return None
+                fetched_at, ttl = row
+                elapsed = time.time() - fetched_at
+                if elapsed > ttl:
+                    return None
+                return int(elapsed)
+            except Exception as exc:
+                import sys
+                print(f"[qualys-mcp] DiskCache.age warning: {exc}", file=sys.stderr)
+                return None
+
+    def size_kb(self):
+        """Return DB file size in KB, or 0."""
+        try:
+            return int(DB_PATH.stat().st_size / 1024) if DB_PATH.exists() else 0
+        except OSError:
+            return 0
+
+    def keys(self):
+        """Return list of non-expired cache keys."""
+        with self._lock:
+            try:
+                if self._conn is None:
+                    return []
+                now = time.time()
+                rows = self._conn.execute(
+                    "SELECT key FROM cache WHERE (? - fetched_at) <= ttl", (now,)
+                ).fetchall()
+                return [r[0] for r in rows]
+            except Exception:
+                return []
+
+
+# Module-level singleton
+disk_cache = DiskCache()

--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -741,6 +741,19 @@ def delete_report(report_id: str) -> dict:
     return {'error': "delete_report has been removed. Use reports(action='delete', report_id='...') instead.", 'replacement': 'reports'}
 
 
+@mcp.tool()
+def qualys_cache_clear(key: str = "") -> str:
+    """Clear the qualys-mcp cache (both in-memory L1 and disk L2).
+    key: optional specific cache key; if empty, clears everything."""
+    from qualys.cache import disk_cache
+    from qualys.api import clear_memory_cache
+    clear_memory_cache(key if key else None)
+    disk_cache.clear(key if key else None)
+    if key:
+        return f"Cache cleared for key: {key}"
+    return "Cache cleared (all keys, both memory and disk)"
+
+
 # ---------------------------------------------------------------------------
 # Startup
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses issue #159

## Summary

Adds a SQLite-backed L2 disk cache so server restarts (eval runs, Claude Desktop reloads) are instant — no Qualys API warmup needed if disk cache is fresh.

## Architecture

- **L1** = existing in-memory dicts (fast, lost on restart)
- **L2** = `~/.cache/qualys-mcp/cache.db` SQLite (survives restarts)
- `QUALYS_MCP_CACHE_DIR` env override for cache location

## New file: `qualys/cache.py`

- `DiskCache` class with thread-safe `get()`, `set()`, `clear()`, `age()`, `size_kb()`, `keys()`
- All SQLite errors caught and logged — never crashes the server
- Module-level singleton: `disk_cache = DiskCache()`

## Per-type TTL constants (all env-overridable)

| Data | TTL | Env var |
|---|---|---|
| VMDR detections | 4h | `CACHE_TTL_VMDR` |
| CSAM assets | 6h | `CACHE_TTL_CSAM` |
| Certificates | 12h | `CACHE_TTL_CERTS` |
| Cloud findings | 6h | `CACHE_TTL_CLOUD` |
| Patch jobs | 1h | `CACHE_TTL_PATCH` |
| Scanners | 12h | `CACHE_TTL_SCANNERS` |
| WAS findings | 4h | `CACHE_TTL_WAS` |
| ETM data | 2h | `CACHE_TTL_ETM` |
| Containers/images | 6h | `CACHE_TTL_CONTAINERS` |

## Changes to `qualys/api.py`

- `_get_or_fetch()`: new `disk_ttl` parameter — checks L2 on L1 miss, writes through after fetch
- `get_detections()`: `disk_ttl=TTL_VMDR`
- `get_was_findings()`: `disk_ttl=TTL_WAS`
- `get_scanner_list()`: L2 check/write with `TTL_SCANNERS`
- `_warmup_vmdr_cache()`: loads from disk and skips API calls on hit
- `clear_memory_cache(key=None)`: clears all L1 cache dicts

## Changes to `qualys/aggregators.py`

- `etm_findings()`: L2 check/write with `TTL_ETM` (no-`qql` path)
- `cache_status_agg()`: adds `disk_cache_path`, `disk_cache_size_kb`, `disk_age_s` per key
- `cache_status_agg(clear=True)`: clears both L1 and disk

## New MCP tool: `qualys_cache_clear`

Clears both in-memory and disk cache. Optional `key` parameter for targeted invalidation.