### PR TITLE
fix: wrap sync Anthropic calls in asyncio.to_thread (#155)

### DIFF
--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -133,7 +133,7 @@ async def run_eval(args):
                         resp = await run_question(
                             client, session, tools, question_text
                         )
-                        judgment = judge_response(
+                        judgment = await judge_response(
                             client,
                             question_text,
                             resp["tool_calls"],
@@ -273,7 +273,7 @@ async def run_conversation_eval(args):
                     history_text = "\n".join(history_lines) if history_lines else "(start of conversation)"
 
                     try:
-                        judgment = judge_conversation_turn(
+                        judgment = await judge_conversation_turn(
                             client,
                             history_text,
                             tr["question"],

--- a/eval/judge.py
+++ b/eval/judge.py
@@ -1,5 +1,6 @@
 """Claude-as-judge scoring logic."""
 
+import asyncio
 import json
 import re
 
@@ -35,7 +36,7 @@ Respond with JSON only:
 {"score": "<label>", "reasoning": "<1-2 sentence explanation>"}"""
 
 
-def judge_response(
+async def judge_response(
     client: anthropic.Anthropic,
     question: str,
     tool_calls: list[dict],
@@ -56,7 +57,9 @@ def judge_response(
 ## Assistant Response
 {response}"""
 
-    resp = _create_message_with_retry(client,
+    resp = await asyncio.to_thread(
+        _create_message_with_retry,
+        client,
         model=JUDGE_MODEL,
         max_tokens=256,
         system=JUDGE_SYSTEM,
@@ -101,7 +104,7 @@ Respond with JSON only:
 {"score": "<label>", "reasoning": "<1-2 sentence explanation>"}"""
 
 
-def judge_conversation_turn(
+async def judge_conversation_turn(
     client: anthropic.Anthropic,
     conversation_history: str,
     current_question: str,
@@ -126,7 +129,9 @@ def judge_conversation_turn(
 ## Assistant Response (this turn)
 {response}"""
 
-    resp = _create_message_with_retry(client,
+    resp = await asyncio.to_thread(
+        _create_message_with_retry,
+        client,
         model=JUDGE_MODEL,
         max_tokens=256,
         system=CONV_JUDGE_SYSTEM,

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -1,5 +1,6 @@
 """Send questions to the MCP server via Claude API with tools enabled."""
 
+import asyncio
 import os
 import sys
 import time
@@ -85,7 +86,9 @@ async def run_question(
     assistant_text = ""
 
     for _ in range(10):  # max iterations
-        resp = _create_message_with_retry(client,
+        resp = await asyncio.to_thread(
+            _create_message_with_retry,
+            client,
             model=RUNNER_MODEL,
             max_tokens=4096,
             system=SYSTEM_PROMPT,
@@ -173,7 +176,9 @@ async def run_conversation(
         assistant_text = ""
 
         for _ in range(10):  # max iterations per turn
-            resp = _create_message_with_retry(client,
+            resp = await asyncio.to_thread(
+                _create_message_with_retry,
+                client,
                 model=RUNNER_MODEL,
                 max_tokens=4096,
                 system=SYSTEM_PROMPT,


### PR DESCRIPTION
Addresses issue #155

The eval harness hung at `session.initialize()` because `_create_message_with_retry()` (synchronous Anthropic API call) was blocking the event loop, starving the FastMCP stdio transport.

**Changes:**
- `eval/runner.py`: Wrap `_create_message_with_retry()` calls in `await asyncio.to_thread()` in both `run_question()` and `run_conversation()`
- `eval/judge.py`: Convert `judge_response()` and `judge_conversation_turn()` to async, wrapping their Anthropic calls similarly
- `eval/__main__.py`: `await` the now-async judge functions

**Tested:** Eval connects, initializes, and begins running questions without hanging.