### PR TITLE
feat: auto-detect today's checkpoint on restart, default interval 1 (#166)

### DIFF
--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -92,16 +92,21 @@ async def run_eval(args):
     # Generate run_id for this run
     run_id = uuid.uuid4().hex[:8]
 
-    # Resume from checkpoint if requested
+    # Resume from checkpoint: auto-detect today's checkpoint unless --fresh
     skipped_ids: set[int] = set()
     resumed_results: list[dict] = []
-    if args.resume:
-        skipped_ids, resumed_results, prev_run_id = load_latest_checkpoint()
+    if not args.fresh:
+        if args.resume:
+            skipped_ids, resumed_results, prev_run_id = load_latest_checkpoint()
+        else:
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            skipped_ids, resumed_results, prev_run_id = load_latest_checkpoint(date_prefix=today)
         if skipped_ids:
             run_id = prev_run_id or run_id
-            print(f"Resuming: loaded {len(skipped_ids)} completed questions from checkpoint (run {run_id})")
+            auto = "" if args.resume else " (auto-detected)"
+            print(f"Resuming{auto}: loaded {len(skipped_ids)} completed questions from checkpoint (run {run_id})")
             questions = [q for q in questions if q["id"] not in skipped_ids]
-        else:
+        elif args.resume:
             print("Resume: no checkpoint found, starting fresh")
 
     print(f"Eval: {len(questions)} questions (of {total_parsed} total)")
@@ -525,13 +530,19 @@ def main():
     parser.add_argument(
         "--checkpoint-interval",
         type=int,
-        default=10,
-        help="Save checkpoint every N questions (default: 10)",
+        default=1,
+        help="Save checkpoint every N questions (default: 1)",
     )
     parser.add_argument(
         "--resume",
         action="store_true",
         help="Resume from the most recent checkpoint file",
+    )
+    parser.add_argument(
+        "--fresh",
+        "--no-resume",
+        action="store_true",
+        help="Ignore any existing checkpoints and start from scratch",
     )
 
     args = parser.parse_args()

--- a/eval/reporter.py
+++ b/eval/reporter.py
@@ -135,16 +135,25 @@ def save_checkpoint(
     return result_file
 
 
-def load_latest_checkpoint(run_id: str | None = None) -> tuple[set[int], list[dict], str | None]:
+def load_latest_checkpoint(
+    run_id: str | None = None, date_prefix: str | None = None
+) -> tuple[set[int], list[dict], str | None]:
     """Find and load the most recent checkpoint file.
 
     If run_id is given, only consider checkpoints for that run.
+    If date_prefix is given (e.g. "2026-03-29"), only consider checkpoints
+    whose filename starts with ``checkpoint_{date_prefix}``.
     Returns (set of completed question IDs, results list, run_id or None).
     """
     if not RESULTS_DIR.exists():
         return set(), [], None
 
-    pattern = f"checkpoint_*_{run_id}.json" if run_id else "checkpoint_*.json"
+    if run_id:
+        pattern = f"checkpoint_*_{run_id}.json"
+    elif date_prefix:
+        pattern = f"checkpoint_{date_prefix}_*.json"
+    else:
+        pattern = "checkpoint_*.json"
     checkpoint_files = sorted(RESULTS_DIR.glob(pattern))
     if not checkpoint_files:
         return set(), [], None


### PR DESCRIPTION
Addresses issue #166

Builds on the checkpointing infrastructure from PR #167 to add auto-detection of today's checkpoint on restart.

## Changes

- **Auto-detection**: On startup, eval automatically checks for checkpoint files from today (`checkpoint_YYYY-MM-DD_*.json`). If found, resumes without any flags needed — prints `Resuming (auto-detected): loaded N completed questions...`
- **`--fresh` / `--no-resume` flag**: Skip auto-detection and start from scratch when you explicitly want a clean run
- **`--resume` still works**: Searches all checkpoints (not just today's), unchanged behavior
- **Default checkpoint interval**: Changed from 10 → 1 (every question), matching the acceptance criteria 'after every question'

## Acceptance criteria verification

- ✅ Results flushed after every question (interval default now 1)
- ✅ On restart, eval detects existing partial run for today and resumes automatically
- ✅ Final result file is identical format to current output
- ✅ If no checkpoint exists, runs from scratch as normal