### PR TITLE
feat: container security tools — vuln counts by image, K8s context, running container details (#173)

### DIFF
--- a/qualys/aggregators.py
+++ b/qualys/aggregators.py
@@ -2709,6 +2709,127 @@ def image_vulns(image_id: str, limit: int = 50, detail: str = "standard") -> dic
 
 
 # ---------------------------------------------------------------------------
+# container_vuln_summary
+# ---------------------------------------------------------------------------
+
+def container_vuln_summary(limit: int = 20, detail: str = "standard") -> dict:
+    """Top container images ranked by critical vulnerability count with severity breakdown."""
+    images = get_images_by_vulns(limit=limit)
+    if not images:
+        return compact({'error': 'No container images found — Container Security may not be enabled.',
+                        'images': [], 'summary': {}})
+
+    ranked = []
+    totals = {'critical': 0, 'high': 0, 'medium': 0, 'low': 0, 'total': 0, 'patchable': 0}
+
+    for img in images:
+        vulns = img.get('vulnerabilities', {}) or {}
+        sev = vulns.get('severity', {}) or {}
+        crit = sev.get('5', 0)
+        high = sev.get('4', 0)
+        med = sev.get('3', 0)
+        low = sev.get('2', 0) + sev.get('1', 0)
+        img_total = crit + high + med + low
+        patchable = vulns.get('patchAvailable', 0)
+        totals['critical'] += crit
+        totals['high'] += high
+        totals['medium'] += med
+        totals['low'] += low
+        totals['total'] += img_total
+        totals['patchable'] += patchable
+
+        ranked.append(compact({
+            'imageId': img.get('imageId', ''),
+            'repo': img.get('repo', ''),
+            'tag': img.get('tag', ''),
+            'created': short_date(img.get('created', '')),
+            'critical': crit, 'high': high, 'medium': med, 'low': low,
+            'total': img_total, 'patchable': patchable,
+        }))
+
+    result = {
+        'summary': totals,
+        'imageCount': len(ranked),
+        'images': ranked,
+    }
+    out = _with_meta(result, 'images', len(ranked))
+    return _apply_detail_level(out, detail, list_keys=['images'])
+
+
+# ---------------------------------------------------------------------------
+# image_vulns_list  (list mode — no image_id)
+# ---------------------------------------------------------------------------
+
+def image_vulns_list(limit: int = 20, detail: str = "standard") -> dict:
+    """List container images ranked by critical vuln count (no specific image_id needed)."""
+    return container_vuln_summary(limit=limit, detail=detail)
+
+
+# ---------------------------------------------------------------------------
+# running_containers
+# ---------------------------------------------------------------------------
+
+def running_containers(limit: int = 50, detail: str = "standard") -> dict:
+    """Running containers with image vulnerability context."""
+    concurrent = _run_concurrent(
+        containers=lambda: get_containers(limit=limit),
+        images=lambda: get_images_by_vulns(limit=200),
+    )
+
+    containers = concurrent.get('containers') or []
+    images_list = concurrent.get('images') or []
+
+    # Build image vuln lookup by imageId
+    img_vulns = {}
+    for img in images_list:
+        iid = img.get('imageId', '')
+        if iid:
+            vulns = img.get('vulnerabilities', {}) or {}
+            sev = vulns.get('severity', {}) or {}
+            img_vulns[iid] = {
+                'critical': sev.get('5', 0), 'high': sev.get('4', 0),
+                'medium': sev.get('3', 0),
+                'patchable': vulns.get('patchAvailable', 0),
+            }
+
+    rows = []
+    for c in containers:
+        iid = c.get('imageId', '')
+        vuln_info = img_vulns.get(iid, {})
+        rows.append(compact({
+            'containerId': c.get('containerId', ''),
+            'name': c.get('name', ''),
+            'imageId': iid,
+            'imageRepo': c.get('imageRepo', '') or c.get('repo', ''),
+            'imageTag': c.get('imageTag', '') or c.get('tag', ''),
+            'state': c.get('state', ''),
+            'host': c.get('hostName', '') or c.get('hostname', ''),
+            'critical': vuln_info.get('critical', 0),
+            'high': vuln_info.get('high', 0),
+            'medium': vuln_info.get('medium', 0),
+            'patchable': vuln_info.get('patchable', 0),
+        }))
+
+    # Sort by critical desc, then high desc
+    rows.sort(key=lambda r: (-r.get('critical', 0), -r.get('high', 0)))
+
+    unpatched_critical = [r for r in rows if r.get('critical', 0) > 0 and r.get('patchable', 0) > 0]
+
+    result = {
+        'summary': {
+            'totalRunning': len(rows),
+            'withCriticalVulns': sum(1 for r in rows if r.get('critical', 0) > 0),
+            'withUnpatchedCritical': len(unpatched_critical),
+        },
+        'containers': rows[:limit],
+        '_k8sNote': 'Kubernetes namespace/pod data is not available on this tenant. '
+                    'Showing container and image-level data instead.',
+    }
+    out = _with_meta(result, 'containers', len(rows))
+    return _apply_detail_level(out, detail, list_keys=['containers'])
+
+
+# ---------------------------------------------------------------------------
 # expiring_certs
 # ---------------------------------------------------------------------------
 

--- a/qualys/api.py
+++ b/qualys/api.py
@@ -1026,9 +1026,16 @@ def get_images(limit=100, severity=None, count_only=False):
     return _paginate_json(url, limit, count_only=count_only)
 
 
-def get_containers(limit=100, count_only=False):
-    """Fetch running containers with pagination."""
-    url = f"{GATEWAY_URL}/csapi/v1.3/containers?filter=state:RUNNING"
+def get_images_by_vulns(limit=50):
+    """Fetch container images ranked by critical vulnerability count (descending)."""
+    url = f"{GATEWAY_URL}/csapi/v1.3/images?sort=vulnerabilities.severity5:desc"
+    return _paginate_json(url, limit, fetch_all=False)
+
+
+def get_containers(limit=100, count_only=False, filter_str=None):
+    """Fetch containers with pagination. Default filter: state:RUNNING."""
+    filt = filter_str or "state:RUNNING"
+    url = f"{GATEWAY_URL}/csapi/v1.3/containers?filter={filt}"
     return _paginate_json(url, limit, count_only=count_only)
 
 

--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -22,6 +22,9 @@ from qualys.aggregators import (
     asset_detail,
     tech_debt,
     image_vulns,
+    image_vulns_list,
+    container_vuln_summary,
+    running_containers,
     expiring_certs,
     webapp_vulns,
     risk_by_tag,
@@ -333,21 +336,59 @@ def get_tech_debt(limit: int = 100, days: int = 30, detail: str = "standard") ->
 
 
 @mcp.tool()
-def get_image_vulns(image_id: str, limit: int = 50, detail: str = "standard") -> dict:
-    """[Container Security] Vulnerabilities for a specific container image — severity breakdown and individual vuln details with fix versions.
+def get_container_vuln_summary(limit: int = 20, detail: str = "standard") -> dict:
+    """[Container Security] Top container images ranked by critical vulnerability count — severity breakdown across all images with patch availability. @fast
 
-    USE WHEN: Investigating vulnerabilities in a specific container image, pre-deployment image scanning review, or container remediation planning.
-    DO NOT USE WHEN: Listing all container images, checking host-based vulnerabilities, or viewing cloud posture.
-    PREFER INSTEAD: get_asset_inventory for listing container images; get_asset for host-based vulnerabilities; get_cloud_risk for cloud posture overview.
+    USE WHEN: "show me vulnerability counts by image", "which container images have the most critical vulns?", container security overview, image risk ranking, or container vulnerability audit.
+    DO NOT USE WHEN: Investigating a single specific image (use get_image_vulns instead), looking at host-level vulnerabilities, or checking cloud posture.
+    PREFER INSTEAD: get_image_vulns for single-image deep dive; get_running_containers for running container context; get_etm_findings for host-level vulnerabilities.
 
     Parameters:
-        image_id: TotalCloud imageId (from get_asset_inventory or get_weekly_priorities container risk section)
-        limit: max vulns to return (default 50)
+        limit: max images to return (default 20). Use higher for full inventory.
 
-    Returns: imageId, repo, tag, created, stats (critical/high/medium/low/total), vulns (list with qid, cve, severity, title, fixVersion).
+    Returns: summary (critical/high/medium/low/total/patchable across all images), imageCount, images (list ranked by critical vulns with repo, tag, severity counts, patchable).
+
+    Performance: ~3s (single paginated API call)."""
+    return container_vuln_summary(limit=limit, detail=detail)
+
+
+@mcp.tool()
+def get_image_vulns(image_id: str = "", limit: int = 50, detail: str = "standard") -> dict:
+    """[Container Security] Vulnerabilities for a specific container image — severity breakdown and individual vuln details with fix versions. Without image_id, lists top images by critical vuln count.
+
+    USE WHEN: Investigating vulnerabilities in a specific container image, pre-deployment image scanning review, or container remediation planning. Also use without image_id to list top vulnerable images.
+    DO NOT USE WHEN: Checking host-based vulnerabilities or viewing cloud posture.
+    PREFER INSTEAD: get_container_vuln_summary for image ranking overview; get_asset for host-based vulnerabilities; get_cloud_risk for cloud posture overview.
+
+    Parameters:
+        image_id: TotalCloud imageId (from get_asset_inventory or get_weekly_priorities container risk section). Leave empty to list top images by critical vuln count.
+        limit: max vulns/images to return (default 50)
+
+    Returns: With image_id: imageId, repo, tag, created, stats (critical/high/medium/low/total), vulns (list with qid, cve, severity, title, fixVersion). Without image_id: ranked list of images with severity counts.
 
     Performance: ~3s (parallel image details + vulns API)."""
+    if not image_id:
+        return image_vulns_list(limit=limit, detail=detail)
     return image_vulns(image_id=image_id, limit=limit, detail=detail)
+
+
+@mcp.tool()
+def get_running_containers(limit: int = 50, detail: str = "standard") -> dict:
+    """[Container Security] Running containers with image vulnerability context — identifies containers with unpatched critical vulns. @slow
+
+    USE WHEN: "show me all running containers with unpatched critical vulns", "which containers are most at risk?", container runtime security audit, or finding containers that need immediate patching.
+    DO NOT USE WHEN: Looking at container images without runtime context (use get_container_vuln_summary), investigating a single image (use get_image_vulns), or checking host-level vulns.
+    PREFER INSTEAD: get_container_vuln_summary for image-level vuln ranking without runtime context; get_image_vulns for single-image deep dive.
+
+    NOTE: Kubernetes namespace/pod-level data (namespaces, pods) is not available on all tenants. This tool returns container and image-level data. For K8s questions, it will indicate when namespace/pod data is unavailable.
+
+    Parameters:
+        limit: max containers to return (default 50)
+
+    Returns: summary (totalRunning, withCriticalVulns, withUnpatchedCritical), containers (list sorted by critical vuln count with containerId, name, imageRepo, imageTag, host, critical/high/medium/patchable counts).
+
+    Performance: ~5s (parallel containers + images API)."""
+    return running_containers(limit=limit, detail=detail)
 
 
 @mcp.tool()


### PR DESCRIPTION
Addresses issue #173

## Changes

**New tools:**
- `get_container_vuln_summary` — ranks images by critical vuln count with severity breakdown and patch availability. Answers 'show me vulnerability counts by image repository'
- `get_running_containers` — running containers joined with image vuln data, sorted by critical count. Answers 'show me all running containers with unpatched critical vulns'. Includes K8s graceful degradation note

**Updated tools:**
- `get_image_vulns` — now works without `image_id` (list mode returns top images by critical vulns)

**API layer (`qualys/api.py`):**
- Added `get_images_by_vulns()` — fetches images sorted by `vulnerabilities.severity5:desc`
- Updated `get_containers()` — accepts optional `filter_str` parameter

**K8s graceful handling:**
- /csapi/v1.3/namespaces and /pods return 404 on this tenant — tools return clear 'Kubernetes context not available — showing image/container level data instead' message

## Quick eval
Score: 80% (14 correct, 4 partial, 0 wrong, 2 tool-error) on 20-question smoke test.