### PR TITLE
fix: patch management response quality (#175)

### DIFF
--- a/qualys/aggregators.py
+++ b/qualys/aggregators.py
@@ -1657,11 +1657,12 @@ def recommendations(detail: str = "standard") -> dict:
     return _apply_detail_level(result, detail, list_keys=['recommendations'])
 
 
-def eliminate_status(detail: str = "standard") -> dict:
+def eliminate_status(detail: str = "standard", status: str = "") -> dict:
     result = {
         'patchManagement': {'windows': {}, 'linux': {}},
         'mitigations': {'windows': {}, 'linux': {}},
         'patchCatalog': {},
+        'patchCounts': {},
         'summary': '',
     }
 
@@ -1674,12 +1675,17 @@ def eliminate_status(detail: str = "standard") -> dict:
         linux_patches=lambda: get_pm_patches_count('Linux'),
         windows_assets=lambda: get_pm_assets('Windows', 5),
         linux_assets=lambda: get_pm_assets('Linux', 5),
+        windows_missing=lambda: get_pm_patches_count('Windows', status='Missing'),
+        linux_missing=lambda: get_pm_patches_count('Linux', status='Missing'),
+        windows_deployed=lambda: get_pm_patches_count('Windows', status='Installed'),
+        linux_deployed=lambda: get_pm_patches_count('Linux', status='Installed'),
     )
 
     all_empty = all(
         not concurrent.get(k)
         for k in ('windows_pm_jobs', 'linux_pm_jobs', 'windows_mtg_jobs', 'linux_mtg_jobs',
-                  'windows_patches', 'linux_patches', 'windows_assets', 'linux_assets')
+                  'windows_patches', 'linux_patches', 'windows_assets', 'linux_assets',
+                  'windows_missing', 'linux_missing', 'windows_deployed', 'linux_deployed')
     )
     if all_empty:
         return _with_meta({
@@ -1699,11 +1705,15 @@ def eliminate_status(detail: str = "standard") -> dict:
     active_patch_jobs = 0
     active_mtg_jobs = 0
 
+    status_filter = status.strip().capitalize() if status else ""
+
     for platform in ['windows', 'linux']:
         plat_key = platform.capitalize()
 
         pm_jobs = concurrent.get(f'{platform}_pm_jobs') or []
         patch_jobs = [j for j in pm_jobs if j.get('subCategory') == 'Patch']
+        if status_filter:
+            patch_jobs = [j for j in patch_jobs if j.get('status', '').capitalize() == status_filter]
         total_patch_jobs += len(patch_jobs)
 
         active = [j for j in patch_jobs if j.get('status') not in ('Disabled', 'Deleted')]
@@ -1737,6 +1747,8 @@ def eliminate_status(detail: str = "standard") -> dict:
         }
 
         mtg_jobs = concurrent.get(f'{platform}_mtg_jobs') or []
+        if status_filter:
+            mtg_jobs = [j for j in mtg_jobs if j.get('status', '').capitalize() == status_filter]
         total_mtg_jobs += len(mtg_jobs)
 
         mtg_active = [j for j in mtg_jobs if j.get('status') not in ('Disabled', 'Deleted')]
@@ -1779,10 +1791,29 @@ def eliminate_status(detail: str = "standard") -> dict:
 
     total_catalog = result['patchCatalog']['windows']['total'] + result['patchCatalog']['linux']['total']
 
+    def _extract_count(data):
+        if isinstance(data, dict):
+            return data.get('patches', {}).get('count', 0) if 'patches' in data else 0
+        return 0
+
+    win_missing = _extract_count(concurrent.get('windows_missing') or {})
+    lin_missing = _extract_count(concurrent.get('linux_missing') or {})
+    win_deployed = _extract_count(concurrent.get('windows_deployed') or {})
+    lin_deployed = _extract_count(concurrent.get('linux_deployed') or {})
+
+    result['patchCounts'] = {
+        'missing': {'windows': win_missing, 'linux': lin_missing, 'total': win_missing + lin_missing},
+        'deployed': {'windows': win_deployed, 'linux': lin_deployed, 'total': win_deployed + lin_deployed},
+    }
+
+    total_missing = win_missing + lin_missing
+    total_deployed = win_deployed + lin_deployed
+
     result['summary'] = (
         f'TruRisk Eliminate: {total_patch_jobs} patch jobs ({active_patch_jobs} active), '
         f'{total_mtg_jobs} mitigation jobs ({active_mtg_jobs} active). '
         f'Patch catalog: {total_catalog:,} patches available. '
+        f'Patches deployed: {total_deployed:,}, missing: {total_missing:,}. '
         f'Use Patch to eliminate risk by deploying fixes. '
         f'Use Mitigate to apply compensating controls when no patch exists.'
     )

--- a/qualys/api.py
+++ b/qualys/api.py
@@ -1224,11 +1224,13 @@ def get_pm_jobs(platform='Windows', limit=10):
         return []
 
 
-def get_pm_patches_count(platform='Windows', group_by=None):
-    """Get patch counts, optionally grouped by vendorSeverity or appFamily"""
+def get_pm_patches_count(platform='Windows', group_by=None, status=None):
+    """Get patch counts, optionally grouped by vendorSeverity or appFamily, filtered by status (e.g. Missing, Deployed, Installed)"""
     url = f"{GATEWAY_URL}/pm/v1/patches/count?platform={platform}"
     if group_by:
         url += f"&groupBy={group_by}"
+    if status:
+        url += f"&status={status}"
     data = api_get(url, gateway=True, not_found_ok=True)
     if data is None:
         return {}

--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -106,11 +106,11 @@ def investigate(topic: str, depth: str = "standard", prior_context: str = "", de
 
 @mcp.tool()
 def get_patch_status(limit: int = 20, tag: str = "", asset_group: str = "", detail: str = "standard") -> dict:
-    """[Patch Management] Patching coverage and gaps — TruRisk distribution across severity tiers and top unpatched assets ranked by risk.
+    """[Patch Posture] TruRisk-based patching coverage and gaps — risk distribution across severity tiers and top unpatched assets ranked by TruRisk score. This is a RISK POSTURE view from CSAM, NOT deployed/missing patch counts from the PM module.
 
-    USE WHEN: "how is our patching going?", "how many assets are unpatched?", assessing patch posture, or identifying top unpatched assets by risk tier.
-    DO NOT USE WHEN: Checking active patch job deployment, viewing PM job details per platform, or looking at single-asset patch details.
-    PREFER INSTEAD: get_eliminate_status when "what patches are deploying right now?" or active job status; get_asset for single-asset patch/vuln details.
+    USE WHEN: "how is our patching going?" (risk posture), "how many assets are unpatched?", assessing patch posture by TruRisk tier, or identifying top unpatched assets by risk score.
+    DO NOT USE WHEN: Asking about deployed vs missing patch counts, failed patch deployments, outstanding patches, or PM job status.
+    PREFER INSTEAD: get_eliminate_status when "how many patches are deployed vs missing?", "what patches failed?", "what Windows patches are outstanding?", or any PM job/deployment question; get_asset for single-asset patch/vuln details.
 
     Parameters:
         limit: max high-risk assets to return (default 20)
@@ -178,17 +178,20 @@ def get_recommendations(detail: str = "standard") -> dict:
 
 
 @mcp.tool()
-def get_eliminate_status(detail: str = "standard") -> dict:
-    """[TruRisk Eliminate] Active patch and mitigation deployment status — PM jobs, MTG jobs, patch catalog size, and managed asset counts for Windows and Linux.
+def get_eliminate_status(status: str = "", detail: str = "standard") -> dict:
+    """[TruRisk Eliminate] Patch deployment status — deployed/missing patch counts, PM jobs, MTG jobs, patch catalog, and managed assets for Windows and Linux.
 
-    USE WHEN: "what patches are deploying right now?", "are patches deploying?", "how many mitigation jobs are running?", "what's our patch catalog size?", or checking active risk elimination progress.
-    DO NOT USE WHEN: Assessing overall patch coverage by risk tier, viewing per-platform PM job details, or checking single-asset patch status.
-    PREFER INSTEAD: get_patch_status when "how is our patching going?" (coverage/gaps summary); get_asset for per-asset details.
+    USE WHEN: "how many patches are deployed vs missing?", "what patches failed to deploy?", "which assets are missing critical patches?", "what Windows patches are outstanding?", "what patches are deploying right now?", "are patches deploying?", "how many mitigation jobs are running?", "what's our patch catalog size?", or checking active risk elimination progress.
+    DO NOT USE WHEN: Assessing overall risk posture by TruRisk tier (use get_patch_status), or checking single-asset patch status (use get_asset).
+    PREFER INSTEAD: get_patch_status when "how is our patching going?" (TruRisk coverage/gaps); get_asset for per-asset details.
 
-    Returns: patchManagement (per-platform: totalJobs, activeJobs, byStatus, recentJobs, managedAssets), mitigations (per-platform: totalJobs, activeJobs, byStatus, recentJobs), patchCatalog (windows/linux totals and severity breakdown), summary.
+    Parameters:
+        status: filter jobs by status (e.g. "Failed", "Completed", "Running"). Empty = all jobs.
+
+    Returns: patchCounts (deployed/missing totals per platform), patchManagement (per-platform: totalJobs, activeJobs, byStatus, recentJobs, managedAssets), mitigations (per-platform: totalJobs, activeJobs, byStatus, recentJobs), patchCatalog (windows/linux totals and severity breakdown), summary.
 
     Performance: ~5s cold / ~3s warm (parallel PM+MTG+catalog queries)."""
-    return eliminate_status(detail=detail)
+    return eliminate_status(status=status, detail=detail)
 
 
 @mcp.tool()


### PR DESCRIPTION
Addresses issue #175

Improves Patch Management response quality by surfacing deployed/missing patch counts directly, adding a status filter for job queries, and updating tool docstrings to route questions to the right tool.

## Changes

- **aggregators.py**: Fetches deployed/missing patch counts from `/pm/v1/patches/count` (with `status=Missing`/`status=Installed`) in parallel alongside existing PM queries. Surfaces these as `patchCounts` in the response with per-platform and total breakdowns. Also adds `status` filter to job filtering so `status='Failed'` returns only failed jobs.
- **api.py**: Adds `status` parameter to `get_pm_patches_count` to support filtering by patch status.
- **qualys_mcp.py**: Updates `get_eliminate_status` to accept a `status` parameter, and rewrites docstrings on both `get_patch_status` and `get_eliminate_status` so the model routes PM-specific questions (deployed vs missing, failed patches, outstanding patches) to `get_eliminate_status` rather than the risk-posture view.