### PR TITLE
fix: TLS protocol detection + cert tool routing (#176)

### DIFF
--- a/qualys/aggregators.py
+++ b/qualys/aggregators.py
@@ -3214,12 +3214,102 @@ def running_containers(limit: int = 50, detail: str = "standard") -> dict:
 
 
 # ---------------------------------------------------------------------------
+# _cert_security_posture  (fast-path for protocol/cipher/renegotiation queries)
+# ---------------------------------------------------------------------------
+
+def _cert_security_posture(protocol_filter: str = "", weak_ciphers: bool = False,
+                           insecure_renegotiation: bool = False, limit: int = 100,
+                           detail: str = "standard") -> dict:
+    """Server-side filtered cert query via CertView v2 — avoids full cert fetch."""
+    filters = []
+    if protocol_filter:
+        filters.append(f"protocol:{protocol_filter}")
+    if insecure_renegotiation:
+        filters.append("insecureRenegotiation:true")
+    if weak_ciphers:
+        # RC4, DES, 3DES are the common weak cipher families
+        filters.append("cipherSuite:RC4,DES,3DES")
+
+    query_label_parts = []
+    if protocol_filter:
+        query_label_parts.append(f"protocol={protocol_filter}")
+    if insecure_renegotiation:
+        query_label_parts.append("insecureRenegotiation")
+    if weak_ciphers:
+        query_label_parts.append("weakCiphers")
+    query_label = ", ".join(query_label_parts)
+
+    all_certs = []
+    for filt in filters:
+        raw = get_certificates_filtered(filt, limit=limit)
+        if raw is None:
+            return {
+                "error": "Certificate management (CertView) is not enabled on this Qualys subscription. "
+                         "Contact your Qualys administrator to enable the CertView module.",
+                "total": 0,
+                "certs": [],
+            }
+        if raw:
+            all_certs.extend(raw)
+
+    # Deduplicate by certificate hash/id
+    seen = set()
+    unique = []
+    for c in all_certs:
+        cid = c.get('hash') or c.get('id') or c.get('serialNumber', '')
+        if cid and cid in seen:
+            continue
+        if cid:
+            seen.add(cid)
+        unique.append(c)
+
+    entries = []
+    for c in unique[:limit]:
+        subject_obj = c.get('subject', {}) or {}
+        hosts_raw = c.get('hosts', []) or []
+        host_entries = []
+        for h in hosts_raw[:5]:
+            host_entries.append({
+                'hostname': h.get('hostname', ''),
+                'ip': h.get('ip', h.get('ipAddress', '')),
+                'port': h.get('port', 443),
+                'protocol': h.get('protocol', '') or h.get('tlsVersion', ''),
+                'cipherSuite': h.get('cipherSuite', '') or h.get('cipher', ''),
+                'insecureRenegotiation': h.get('insecureRenegotiation', False),
+            })
+        entries.append({
+            'subject': subject_obj.get('commonName', ''),
+            'serialNumber': c.get('serialNumber', ''),
+            'validTo': (c.get('validTo', '') or '')[:10],
+            'hosts': host_entries,
+        })
+
+    result = {
+        'query': query_label,
+        'total': len(entries),
+        'certs': entries,
+    }
+    out = _with_meta(result, 'certs', len(entries))
+    return _apply_detail_level(out, detail, list_keys=['certs'])
+
+
+# ---------------------------------------------------------------------------
 # expiring_certs
 # ---------------------------------------------------------------------------
 
 def expiring_certs(days: int = 90, include_expired: bool = True, weak_only: bool = False,
-                   limit: int = 100, detail: str = "standard") -> dict:
-    """SSL/TLS certificate expiry monitoring and configuration issue detection."""
+                   limit: int = 100, detail: str = "standard",
+                   protocol_filter: str = "", weak_ciphers: bool = False,
+                   insecure_renegotiation: bool = False) -> dict:
+    """SSL/TLS certificate expiry monitoring, TLS protocol detection, and configuration issue detection."""
+
+    # --- Fast path: server-side filtered queries via CertView v2 ---
+    if protocol_filter or weak_ciphers or insecure_renegotiation:
+        return _cert_security_posture(
+            protocol_filter=protocol_filter, weak_ciphers=weak_ciphers,
+            insecure_renegotiation=insecure_renegotiation, limit=limit, detail=detail,
+        )
+
     result = {
         'days': days,
         'summary': {

--- a/qualys/api.py
+++ b/qualys/api.py
@@ -1126,6 +1126,20 @@ def get_certificates(limit=100, days_expiring=None):
         return None
 
 
+def get_certificates_filtered(filter_expr: str, limit: int = 100):
+    """Fetch certificates from CertView v2 with an arbitrary filter expression.
+
+    Examples:
+        get_certificates_filtered("protocol:TLSv1.0")
+        get_certificates_filtered("insecureRenegotiation:true")
+    """
+    url = f"{GATEWAY_URL}/certview/v2/certificates?pageSize={min(limit, 100)}&filter={quote(filter_expr)}"
+    try:
+        return _paginate_json(url, limit, not_found_ok=True)
+    except Exception:
+        return None
+
+
 def _fetch_ioc_events(limit=200):
     """Fetch events from the unified /ioc/v1/events endpoint."""
     url = f"{GATEWAY_URL}/ioc/v1/events?pageSize={min(limit, 200)}"

--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -454,10 +454,12 @@ def get_running_containers(limit: int = 50, detail: str = "standard") -> dict:
 
 @mcp.tool()
 def get_expiring_certs(days: int = 90, include_expired: bool = True, weak_only: bool = False,
-                       limit: int = 100, detail: str = "standard") -> dict:
-    """[CertView] SSL/TLS certificate expiry monitoring and configuration issue detection — expiring/expired certs, weak keys, SHA-1, self-signed, and TLS 1.0/1.1 usage.
+                       limit: int = 100, detail: str = "standard",
+                       protocol_filter: str = "", weak_ciphers: bool = False,
+                       insecure_renegotiation: bool = False) -> dict:
+    """[CertView] SSL/TLS certificate expiry, TLS version detection, protocol security, and configuration issue detection — expiring/expired certs, weak keys, SHA-1, self-signed, TLS 1.0/1.1, insecure renegotiation, weak ciphers, and SSL protocol analysis.
 
-    USE WHEN: "which SSL certs expire soon?", certificate expiry audit, weak cipher detection, self-signed cert inventory, TLS version compliance, or outage prevention.
+    USE WHEN: "which SSL certs expire soon?", certificate expiry audit, weak cipher detection, self-signed cert inventory, TLS version compliance, insecure renegotiation check, SSL protocol detection, or outage prevention.
     DO NOT USE WHEN: Scanning for host vulnerabilities, checking cloud posture, or general security health overview.
     PREFER INSTEAD: get_etm_findings for vulnerability scanning; get_cloud_risk for cloud posture; get_morning_report or get_weekly_priorities for general security health.
 
@@ -466,20 +468,29 @@ def get_expiring_certs(days: int = 90, include_expired: bool = True, weak_only: 
       - include_expired: Include already-expired certs in results (default True)
       - weak_only: Only return certs that have at least one issue (default False)
       - limit: Max certs to return (default 100)
+      - protocol_filter: Filter by TLS/SSL version — "TLSv1.0", "TLSv1.1", "TLSv1.2", "TLSv1.3", "SSLv3" (default: no filter)
+      - weak_ciphers: Return only certs using weak ciphers like RC4, DES, 3DES (default False)
+      - insecure_renegotiation: Return only certs with insecure TLS renegotiation enabled (default False)
 
     **Example questions:**
       - "Which SSL certs expire in the next 30 days?" → get_expiring_certs(days=30)
       - "Are any certificates already expired?" → get_expiring_certs(include_expired=True)
-      - "Which servers are using weak cipher suites?" → get_expiring_certs(weak_only=True)
+      - "Which servers are using weak cipher suites?" → get_expiring_certs(weak_ciphers=True)
       - "Show me all self-signed certificates" → get_expiring_certs(weak_only=True)
-      - "Are any servers still using TLS 1.0?" → get_expiring_certs(weak_only=True)
+      - "Are any servers still using TLS 1.0?" → get_expiring_certs(protocol_filter="TLSv1.0")
+      - "Are any servers still using TLS 1.1?" → get_expiring_certs(protocol_filter="TLSv1.1")
+      - "Which servers support insecure renegotiation?" → get_expiring_certs(insecure_renegotiation=True)
+      - "Show servers on SSLv3" → get_expiring_certs(protocol_filter="SSLv3")
+      - "Which servers use TLS 1.2?" → get_expiring_certs(protocol_filter="TLSv1.2")
 
-    Returns: summary (total, expired, expiring30Days, expiring90Days, weakCiphers, selfSigned, weakKeySize, tls10or11), expiringSoon (list with subject, expiryDate, daysRemaining, host, grade, issues), issues (flat list with host, issue, severity).
+    Returns: When protocol_filter / weak_ciphers / insecure_renegotiation is set → concise list with hostname, IP, port, and relevant protocol/cipher info. Otherwise → summary (total, expired, expiring30Days, expiring90Days, weakCiphers, selfSigned, weakKeySize, tls10or11), expiringSoon, issues.
 
     **Grades:** A = no issues, B = nearing expiry (<30 days), C = self-signed or weak key, F = expired or SHA-1.
 
-    Performance: ~5s cold / ~3s warm."""
-    return expiring_certs(days=days, include_expired=include_expired, weak_only=weak_only, limit=limit, detail=detail)
+    Performance: ~5s cold / ~3s warm. Protocol/cipher/renegotiation filters use server-side filtering and are faster."""
+    return expiring_certs(days=days, include_expired=include_expired, weak_only=weak_only, limit=limit, detail=detail,
+                          protocol_filter=protocol_filter, weak_ciphers=weak_ciphers,
+                          insecure_renegotiation=insecure_renegotiation)
 
 
 @mcp.tool()


### PR DESCRIPTION
Addresses issue #176

Extends  / cert tool with new parameters:
- `protocol_filter` — filter by TLS version (TLSv1.0, TLSv1.1, SSLv3, etc.)
- `weak_ciphers` — return certs using RC4, DES, 3DES
- `insecure_renegotiation` — return certs with insecure renegotiation flag set

Also updates the tool description/docstring to include 'TLS version', 'insecure renegotiation', 'weak cipher' keywords so the model routes these questions to the cert tool rather than VMDR tools.