### PR TITLE
feat: eval timing + cache metrics (#178)

### DIFF
--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -15,6 +15,7 @@ import json as _json
 import os
 import random
 import sys
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -36,7 +37,9 @@ from .reporter import (
     compute_summary,
     get_previous_run,
     load_latest_checkpoint,
+    parse_perf_log,
     print_summary,
+    print_timing_summary,
     save_checkpoint,
     save_results,
 )
@@ -127,8 +130,14 @@ async def run_eval(args):
             print(f"Error: {var} not set")
             sys.exit(1)
 
+    # Set up perf logging sidecar
+    perf_log_path = f"/tmp/mcp_perf_{run_id}.jsonl"
+    os.environ["MCP_PERF_LOG"] = perf_log_path
+
     client = anthropic.Anthropic()
     server_params = get_server_params()
+
+    run_t0 = time.perf_counter()
 
     async with stdio_client(server_params) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
@@ -136,6 +145,8 @@ async def run_eval(args):
             tools = await get_mcp_tools(session)
             print(f"MCP server connected: {len(tools)} tools available")
             print()
+
+            warmup_seconds = round(time.perf_counter() - run_t0, 2)
 
             results = []
             sem = asyncio.Semaphore(args.concurrency)
@@ -161,6 +172,8 @@ async def run_eval(args):
                     variant_tag = f" (v{variant_index})" if variant_index > 0 else ""
                     print(f"{prefix} {q['category']} — {question_text[:60]}...{variant_tag}")
 
+                    q_t0 = time.perf_counter()
+                    timed_out = False
                     try:
                         resp = await asyncio.wait_for(
                             run_question(client, session, tools, question_text),
@@ -179,12 +192,14 @@ async def run_eval(args):
                             "score": "tool-error",
                             "reasoning": f"Question timed out after {QUESTION_TIMEOUT}s",
                         }
+                        timed_out = True
                     except Exception as e:
                         resp = {"response": "", "tool_calls": []}
                         judgment = {
                             "score": "tool-error",
                             "reasoning": f"Exception: {e}",
                         }
+                    elapsed = round(time.perf_counter() - q_t0, 2)
 
                     result = {
                         "id": q["id"],
@@ -198,12 +213,14 @@ async def run_eval(args):
                         "reasoning": judgment["reasoning"],
                         "tool_calls": resp["tool_calls"],
                         "response": resp["response"],
+                        "elapsed_seconds": elapsed,
+                        "timed_out": timed_out,
                     }
 
                     icon = {"correct": "✅", "partial": "⚠️", "wrong": "❌", "tool-error": "💥"}.get(
                         judgment["score"], "?"
                     )
-                    print(f"{prefix} {icon} {judgment['score']} — {judgment['reasoning'][:80]}")
+                    print(f"{prefix} {icon} {judgment['score']} ({elapsed:.1f}s) — {judgment['reasoning'][:80]}")
                     return result
 
             # MCP stdio transport is single-connection, so questions run sequentially
@@ -218,14 +235,42 @@ async def run_eval(args):
                     cp = save_checkpoint(all_results, now_ts, run_id, RUNNER_MODEL)
                     print(f"  💾 Checkpoint saved ({len(all_results)} questions) → {cp.name}")
 
+    total_seconds = round(time.perf_counter() - run_t0, 2)
+
     # Merge resumed results with new results for final output
     results = resumed_results + results
+
+    # Compute timing stats from per-question elapsed_seconds
+    elapsed_list = [r["elapsed_seconds"] for r in results if "elapsed_seconds" in r]
+    elapsed_sorted = sorted(elapsed_list) if elapsed_list else [0]
+    timeout_count = sum(1 for r in results if r.get("timed_out"))
+
+    def _percentile(sorted_vals, pct):
+        idx = int(len(sorted_vals) * pct / 100)
+        return sorted_vals[min(idx, len(sorted_vals) - 1)]
+
+    # Parse perf log for cache/API metrics
+    perf = parse_perf_log(perf_log_path)
+
+    timing = {
+        "total_seconds": total_seconds,
+        "warmup_seconds": warmup_seconds,
+        "avg_per_question": round(sum(elapsed_list) / len(elapsed_list), 1) if elapsed_list else 0,
+        "p50_per_question": round(_percentile(elapsed_sorted, 50), 1),
+        "p95_per_question": round(_percentile(elapsed_sorted, 95), 1),
+        "max_per_question": round(max(elapsed_list), 1) if elapsed_list else 0,
+        "timeouts": timeout_count,
+        "cache_hits_l1": perf["cache_hits_l1"],
+        "cache_hits_l2": perf["cache_hits_l2"],
+        "cache_misses": perf["cache_misses"],
+        "api_calls": perf["api_calls"],
+    }
 
     # Summarize and save
     summary = compute_summary(results)
     now = datetime.now(timezone.utc)
     run_date = now.strftime("%Y-%m-%d_%H%M%S")
-    result_file = save_results(results, summary, run_date, RUNNER_MODEL)
+    result_file = save_results(results, summary, run_date, RUNNER_MODEL, timing=timing)
     print(f"\nResults saved to {result_file}")
 
     # Clean up checkpoint files from this run on success
@@ -240,11 +285,19 @@ async def run_eval(args):
             result_file.parent.glob("*.json")
         )[-2].name if len(list(result_file.parent.glob("*.json"))) > 1 else "previous"
     print_summary(summary, run_date, result_file, prev_run)
+    print_timing_summary(timing)
 
     # Update questions file if requested
     if not args.no_update:
         update_questions_file(QUESTIONS_PATH, results)
         print(f"\nUpdated coverage tags in {QUESTIONS_PATH}")
+
+    # Clean up perf log sidecar
+    try:
+        os.unlink(perf_log_path)
+    except OSError:
+        pass
+    os.environ.pop("MCP_PERF_LOG", None)
 
     # Threshold check
     print(f"\n{'=' * 60}")

--- a/eval/reporter.py
+++ b/eval/reporter.py
@@ -177,7 +177,8 @@ def cleanup_checkpoints(run_id: str) -> int:
 
 
 def save_results(
-    results: list[dict], summary: dict, run_date: str, model: str
+    results: list[dict], summary: dict, run_date: str, model: str,
+    timing: dict | None = None,
 ) -> Path:
     """Save results to eval_results/YYYY-MM-DD.json. Returns the file path."""
     RESULTS_DIR.mkdir(exist_ok=True)
@@ -202,6 +203,70 @@ def save_results(
         },
         "questions": results,
     }
+    if timing:
+        output["timing"] = timing
 
     result_file.write_text(json.dumps(output, indent=2))
     return result_file
+
+
+def parse_perf_log(path: str) -> dict:
+    """Parse MCP perf JSONL sidecar into cache/API summary counts."""
+    result = {"cache_hits_l1": 0, "cache_hits_l2": 0, "cache_misses": 0, "api_calls": {}}
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                entry = json.loads(line)
+                event = entry.get("event")
+                if event == "cache_hit":
+                    level = entry.get("level", "L1")
+                    if level == "L1":
+                        result["cache_hits_l1"] += 1
+                    else:
+                        result["cache_hits_l2"] += 1
+                elif event == "cache_miss":
+                    result["cache_misses"] += 1
+                elif event == "api_call":
+                    provider = entry.get("provider", "unknown")
+                    result["api_calls"][provider] = result["api_calls"].get(provider, 0) + 1
+    except FileNotFoundError:
+        pass
+    return result
+
+
+def _fmt_duration(seconds: float) -> str:
+    """Format seconds into human-readable duration (e.g. '5h58m' or '42s')."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    if minutes < 60:
+        return f"{minutes}m{secs}s" if secs else f"{minutes}m"
+    hours = minutes // 60
+    mins = minutes % 60
+    return f"{hours}h{mins:02d}m" if mins else f"{hours}h"
+
+
+def print_timing_summary(timing: dict) -> None:
+    """Print timing, cache, and API call summary table."""
+    total = _fmt_duration(timing["total_seconds"])
+    warmup = _fmt_duration(timing["warmup_seconds"])
+    avg = f"{timing['avg_per_question']}s/q"
+    p95 = f"{timing['p95_per_question']}s"
+    timeouts = timing["timeouts"]
+
+    print()
+    print(f"Timing:  total={total}  warmup={warmup}  avg={avg}  p95={p95}  timeouts={timeouts}")
+
+    l1 = timing.get("cache_hits_l1", 0)
+    l2 = timing.get("cache_hits_l2", 0)
+    miss = timing.get("cache_misses", 0)
+    print(f"Cache:   L1 hits={l1}  L2 hits={l2}  miss={miss}")
+
+    api = timing.get("api_calls", {})
+    if api:
+        parts = [f"{k.upper()}={v}" for k, v in sorted(api.items())]
+        print(f"APIs:    {'  '.join(parts)}")

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -315,6 +315,8 @@ def get_server_params() -> StdioServerParameters:
         env["QUALYS_BASE_URL"] = os.environ["QUALYS_BASE_URL"]
     if os.environ.get("QUALYS_GATEWAY_URL"):
         env["QUALYS_GATEWAY_URL"] = os.environ["QUALYS_GATEWAY_URL"]
+    if os.environ.get("MCP_PERF_LOG"):
+        env["MCP_PERF_LOG"] = os.environ["MCP_PERF_LOG"]
     if not env.get("QUALYS_POD") and not env.get("QUALYS_BASE_URL"):
         raise EnvironmentError("Set QUALYS_POD or QUALYS_BASE_URL in environment")
     return StdioServerParameters(

--- a/qualys/api.py
+++ b/qualys/api.py
@@ -34,6 +34,47 @@ from qualys.cache import (
 RETRY_STATUS = {429, 503, 502}
 KB_CONFLICT_RETRY_STATUS = {409}
 MAX_RETRIES = 4
+
+# ---------------------------------------------------------------------------
+# Performance logging (opt-in via MCP_PERF_LOG env var)
+# ---------------------------------------------------------------------------
+
+_PERF_LOG_PATH = os.environ.get("MCP_PERF_LOG")
+_PERF_LOG_LOCK = threading.Lock()
+
+
+def _perf_log(event: str, **fields):
+    """Append a JSONL entry to the perf log file (if MCP_PERF_LOG is set)."""
+    if not _PERF_LOG_PATH:
+        return
+    entry = {"event": event, "ts": time.time(), **fields}
+    try:
+        line = json.dumps(entry) + "\n"
+        with _PERF_LOG_LOCK:
+            with open(_PERF_LOG_PATH, "a") as f:
+                f.write(line)
+    except Exception:
+        pass
+
+
+def _provider_from_url(url: str) -> str:
+    """Detect Qualys API provider from URL path."""
+    if "/csam/" in url or "/cerberus/" in url:
+        return "csam"
+    if "/cloudview" in url:
+        return "cloudview"
+    if "/pm/" in url:
+        return "pm"
+    if "/etm/" in url:
+        return "etm"
+    if "qps.qualys.com" in url or "/qps/" in url:
+        return "vmdr"
+    if "/was/" in url:
+        return "was"
+    # Default: base URL means VMDR, gateway means csapi
+    if "/api/2.0/" in url:
+        return "vmdr"
+    return "csapi"
 KB_CONFLICT_MAX_RETRIES = 3
 KB_CONFLICT_BASE_DELAY = 3  # seconds
 KB_BUSY_MSG = "Knowledge base export is currently busy (concurrent request in progress). Please try again in a moment."
@@ -269,6 +310,7 @@ def _get_or_fetch(cache_dict, cache_time_dict, key, fetch_fn, ttl, disk_ttl=None
     now = datetime.now(timezone.utc)
     cached_time = cache_time_dict.get(key)
     if key in cache_dict and cached_time and (now - cached_time).total_seconds() < ttl:
+        _perf_log("cache_hit", key=key, level="L1")
         return cache_dict[key]
 
     # L2 disk cache check (before acquiring inflight lock)
@@ -278,6 +320,7 @@ def _get_or_fetch(cache_dict, cache_time_dict, key, fetch_fn, ttl, disk_ttl=None
             cache_dict[key] = disk_hit
             cache_time_dict[key] = datetime.now(timezone.utc)
             _log(f"Disk cache hit for {key}")
+            _perf_log("cache_hit", key=key, level="L2")
             return disk_hit
 
     with _inflight_lock:
@@ -305,6 +348,7 @@ def _get_or_fetch(cache_dict, cache_time_dict, key, fetch_fn, ttl, disk_ttl=None
         cache_time_dict[key] = datetime.now(timezone.utc)
         if disk_ttl is not None:
             disk_cache.set(key, result, disk_ttl)
+        _perf_log("cache_miss", key=key)
         return result
     finally:
         with _inflight_lock:
@@ -378,6 +422,8 @@ def get_bearer_token():
 
 
 def api_get(url, gateway=False, timeout=30, not_found_ok=False, server_error_sentinel=None):
+    provider = _provider_from_url(url)
+    _perf_log("api_call", provider=provider, endpoint=url.split("?")[0])
     for attempt in range(MAX_RETRIES):
         req = Request(url)
         if gateway:
@@ -429,6 +475,7 @@ def api_get(url, gateway=False, timeout=30, not_found_ok=False, server_error_sen
 
 def _csam_request(url, body, timeout=30):
     """POST to a CSAM endpoint with retry logic for 429/503/502."""
+    _perf_log("api_call", provider="csam", endpoint=url.split("?")[0])
     token = get_bearer_token()
     for attempt in range(CSAM_MAX_RETRIES):
         req = Request(url, data=body.encode(), method='POST')
@@ -479,6 +526,7 @@ def _is_etm_401(val):
 
 def etm_api(method, path, body=None, timeout=60):
     """Call ETM API. Returns parsed JSON, ETM_401_SENTINEL on 401, None on 404 or other errors."""
+    _perf_log("api_call", provider="etm", endpoint=path)
     token = get_bearer_token()
     url = f"{GATEWAY_URL}{path}"
     data = json.dumps(body).encode() if body else None
@@ -506,6 +554,7 @@ def etm_api(method, path, body=None, timeout=60):
 
 def etm_download(report_id, resource_name, timeout=60):
     """Download ETM report resource as parsed JSON list."""
+    _perf_log("api_call", provider="etm", endpoint=f"/etm/reports/{report_id}/{resource_name}")
     token = get_bearer_token()
     url = f"{GATEWAY_URL}/etm/api/rest/v1/reports/{report_id}/resources/{resource_name}"
     req = Request(url, method='GET')


### PR DESCRIPTION
Addresses issue #178

Track per-question wall time, cache hit rates (L1/L2 separately), and API call counts per provider across eval runs.

## Changes

- **qualys/api.py**: Structured JSON logging to sidecar JSONL file when `MCP_PERF_LOG` env var is set. Logs cache hits (L1/L2), cache misses, and API calls with provider detection from URL pattern.
- **eval/runner.py**: Records `time.perf_counter()` before/after each `run_question()` call; stores `elapsed_seconds` and `timed_out` per question.
- **eval/__main__.py**: Sets `MCP_PERF_LOG` env var before starting server; records warmup time; parses sidecar JSONL at end to aggregate cache/API stats; emits `timing` block in result JSON.
- **eval/reporter.py**: Prints timing summary table after score table (Timing / Cache / APIs rows).

## Result JSON schema

```json
{
  "timing": {
    "total_seconds": 21420,
    "warmup_seconds": 45,
    "avg_per_question": 42.4,
    "p50_per_question": 38.1,
    "p95_per_question": 180,
    "max_per_question": 180,
    "timeouts": 21,
    "cache_hits_l1": 1840,
    "cache_hits_l2": 27,
    "cache_misses": 213,
    "api_calls": { "vmdr": 5, "csam": 87, "cloudview": 34 }
  }
}
```