### PR TITLE
fix: patch management — add outstanding patches from /pm/v1/patches endpoint (#190)

### DIFF
--- a/eval/routing_eval.py
+++ b/eval/routing_eval.py
@@ -215,6 +215,44 @@ ROUTING_CASES: list[RoutingCase] = [
         "Coverage check for top vulns list",
         wrong_tools=["get_eliminate_status"],
     ),
+
+    # Outstanding patches
+    RoutingCase(
+        "What Windows patches are outstanding?",
+        "get_outstanding_patches",
+        "Outstanding Windows patches list",
+        wrong_tools=["get_eliminate_status", "get_patch_status"],
+    ),
+    RoutingCase(
+        "Which patches require a reboot?",
+        "get_outstanding_patches",
+        "Reboot-required patches",
+        wrong_tools=["get_eliminate_status"],
+    ),
+    RoutingCase(
+        "What critical patches are missing?",
+        "get_outstanding_patches",
+        "Missing critical patches by severity",
+        wrong_tools=["get_eliminate_status", "get_patch_status"],
+    ),
+    RoutingCase(
+        "What security patches need to be deployed?",
+        "get_outstanding_patches",
+        "Outstanding security patches",
+        wrong_tools=["get_eliminate_status"],
+    ),
+    RoutingCase(
+        "How many patches are outstanding on Linux?",
+        "get_outstanding_patches",
+        "Linux outstanding patch count",
+        wrong_tools=["get_eliminate_status"],
+    ),
+    RoutingCase(
+        "List the top missing patches by severity.",
+        "get_outstanding_patches",
+        "Missing patches sorted by severity",
+        wrong_tools=["get_eliminate_status", "get_patch_status"],
+    ),
 ]
 
 

--- a/qualys/aggregators.py
+++ b/qualys/aggregators.py
@@ -1883,6 +1883,115 @@ def eliminate_status(detail: str = "standard", status: str = "") -> dict:
     return _apply_detail_level(result, detail)
 
 
+def outstanding_patches(platform: str = "", severity: str = "",
+                        security_only: bool = False, reboot_only: bool = False,
+                        limit: int = 30, detail: str = "standard") -> dict:
+    """Fetch outstanding (missing) patches from PM module with grouping and filters."""
+    platforms = []
+    if platform:
+        platforms = [platform.capitalize()]
+    else:
+        platforms = ['Windows', 'Linux']
+
+    tasks = {}
+    for p in platforms:
+        tasks[f'{p.lower()}_patches'] = lambda p=p: get_pm_patches(p, status='Missing', page_size=50)
+
+    concurrent = _run_concurrent(**tasks)
+
+    all_patches = []
+    for p in platforms:
+        patches = concurrent.get(f'{p.lower()}_patches') or []
+        for patch in patches:
+            patch['_platform'] = p
+        all_patches.extend(patches)
+
+    if not all_patches:
+        return _with_meta({
+            'message': 'No outstanding patches found, or Patch Management module is not enabled.',
+            'patches': [],
+            'summary': 'No outstanding patches found.',
+        })
+
+    # Apply filters
+    filtered = all_patches
+    if severity:
+        sev = severity.capitalize()
+        filtered = [p for p in filtered if (p.get('vendorSeverity') or '').capitalize() == sev]
+    if security_only:
+        filtered = [p for p in filtered if p.get('isSecurity')]
+    if reboot_only:
+        filtered = [p for p in filtered if p.get('rebootRequired')]
+
+    # Sort by missingCount descending
+    filtered.sort(key=lambda p: p.get('missingCount', 0), reverse=True)
+    top_patches = filtered[:limit]
+
+    # Build groupings
+    by_severity = {}
+    security_count = 0
+    nonsecurity_count = 0
+    reboot_count = 0
+    for p in filtered:
+        sev = p.get('vendorSeverity') or 'Unspecified'
+        by_severity[sev] = by_severity.get(sev, 0) + 1
+        if p.get('isSecurity'):
+            security_count += 1
+        else:
+            nonsecurity_count += 1
+        if p.get('rebootRequired'):
+            reboot_count += 1
+
+    by_platform = {}
+    for p in filtered:
+        plat = p.get('_platform', 'Unknown')
+        by_platform[plat] = by_platform.get(plat, 0) + 1
+
+    patch_list = []
+    for p in top_patches:
+        entry = {
+            'title': p.get('title', ''),
+            'platform': p.get('_platform', ''),
+            'missingCount': p.get('missingCount', 0),
+            'installedCount': p.get('installedCount', 0),
+            'vendorSeverity': p.get('vendorSeverity', ''),
+            'isSecurity': p.get('isSecurity', False),
+            'rebootRequired': p.get('rebootRequired', False),
+            'category': p.get('category', ''),
+        }
+        cves = p.get('cve') or p.get('cves') or []
+        if cves:
+            entry['cves'] = cves[:5]
+        kb = p.get('kb') or p.get('bulletin') or ''
+        if kb:
+            entry['kb'] = kb
+        patch_list.append(entry)
+
+    total = len(filtered)
+    top_missing = sum(p.get('missingCount', 0) for p in top_patches)
+    sev_str = ', '.join(f'{k}: {v}' for k, v in sorted(by_severity.items()))
+
+    result = {
+        'patches': patch_list,
+        'total': total,
+        'showing': len(patch_list),
+        'bySeverity': by_severity,
+        'byPlatform': by_platform,
+        'securityPatches': security_count,
+        'nonSecurityPatches': nonsecurity_count,
+        'rebootRequired': reboot_count,
+        'summary': (
+            f'{total} outstanding patches ({sev_str}). '
+            f'Security: {security_count}, non-security: {nonsecurity_count}. '
+            f'Reboot required: {reboot_count}. '
+            f'Top {len(patch_list)} patches affect {top_missing:,} asset-patch pairs.'
+        ),
+    }
+
+    result = _with_meta(result, 'patches', total)
+    return _apply_detail_level(result, detail, list_keys=['patches'])
+
+
 def eliminate_coverage(qids: list = None, cves: list = None, detail: str = "standard") -> dict:
     """Check which QIDs or CVEs have Eliminate mitigations available in the catalog."""
     if not qids and not cves:

--- a/qualys/api.py
+++ b/qualys/api.py
@@ -1312,6 +1312,23 @@ def get_pm_assets(platform='Windows', limit=10):
         return []
 
 
+def get_pm_patches(platform='Windows', status=None, page_size=50):
+    """Get patch list from PM module, optionally filtered by status (e.g. Missing, Installed)."""
+    url = f"{GATEWAY_URL}/pm/v1/patches?platform={platform}&pageSize={page_size}"
+    if status:
+        url += f"&status={status}"
+    data = api_get(url, gateway=True, not_found_ok=True)
+    if data is None:
+        return []
+    try:
+        parsed = json.loads(data)
+        if isinstance(parsed, list):
+            return parsed
+        return parsed.get('patches', parsed.get('data', []))
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
 def get_pm_job_summary(job_id):
     """Get deployment job result summary"""
     data = api_get(f"{GATEWAY_URL}/pm/v1/deploymentjob/{job_id}/deploymentjobresult/summary", gateway=True)

--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -13,6 +13,7 @@ from qualys.aggregators import (
     search_vulns_agg,
     recommendations,
     eliminate_status,
+    outstanding_patches,
     eliminate_coverage,
     scanner_health,
     etm_findings,
@@ -182,9 +183,9 @@ def get_recommendations(detail: str = "standard") -> dict:
 def get_eliminate_status(status: str = "", detail: str = "standard") -> dict:
     """[TruRisk Eliminate] Patch deployment status — deployed/missing patch counts, PM jobs, MTG jobs, patch catalog, deployment success rates, mitigation technique breakdown, and managed assets for Windows and Linux.
 
-    USE WHEN: "how many patches are deployed vs missing?", "what patches failed to deploy?", "what's the success rate of our patch deployments?", "what mitigation techniques are being used?", "which assets are missing critical patches?", "what Windows patches are outstanding?", "what patches are deploying right now?", "are patches deploying?", "how many mitigation jobs are running?", "what's our patch catalog size?", or checking active risk elimination progress.
-    DO NOT USE WHEN: Assessing overall risk posture by TruRisk tier (use get_patch_status), checking single-asset patch status (use get_asset), or checking mitigation coverage for specific QIDs/CVEs (use get_eliminate_coverage).
-    PREFER INSTEAD: get_patch_status when "how is our patching going?" (TruRisk coverage/gaps); get_asset for per-asset details; get_eliminate_coverage when checking which vulns have mitigations available.
+    USE WHEN: "how many patches are deployed vs missing?", "what patches failed to deploy?", "what's the success rate of our patch deployments?", "what mitigation techniques are being used?", "what patches are deploying right now?", "are patches deploying?", "how many mitigation jobs are running?", "what's our patch catalog size?", or checking active risk elimination progress.
+    DO NOT USE WHEN: Assessing overall risk posture by TruRisk tier (use get_patch_status), checking single-asset patch status (use get_asset), checking mitigation coverage for specific QIDs/CVEs (use get_eliminate_coverage), or listing outstanding/missing patches by name (use get_outstanding_patches).
+    PREFER INSTEAD: get_patch_status when "how is our patching going?" (TruRisk coverage/gaps); get_asset for per-asset details; get_eliminate_coverage when checking which vulns have mitigations available; get_outstanding_patches for "what patches are outstanding?", "which patches need to be deployed?", "missing patches by severity".
 
     Parameters:
         status: filter jobs by status (e.g. "Failed", "Completed", "Running"). "Running" returns in-progress jobs. Empty = all jobs. Status is passed to the API for server-side filtering.
@@ -193,6 +194,27 @@ def get_eliminate_status(status: str = "", detail: str = "standard") -> dict:
 
     Performance: ~5s cold / ~3s warm (parallel PM+MTG+catalog queries)."""
     return eliminate_status(status=status, detail=detail)
+
+
+@mcp.tool()
+def get_outstanding_patches(platform: str = "", severity: str = "", security_only: bool = False, reboot_only: bool = False, limit: int = 30, detail: str = "standard") -> dict:
+    """[Patch Management] Outstanding (missing) patches — patch names, missing counts, severity, security flag, reboot requirement, and CVEs addressed.
+
+    USE WHEN: "what patches are outstanding?", "which Windows patches are missing?", "what security patches need to be deployed?", "which patches require a reboot?", "what critical patches are outstanding?", "list missing patches by severity", "what patches are we missing on Linux?", "how many patches are outstanding?", "what are the top missing patches?".
+    DO NOT USE WHEN: Checking deployment job status (use get_eliminate_status), checking overall risk posture (use get_patch_status), or checking mitigation coverage for specific QIDs/CVEs (use get_eliminate_coverage).
+    PREFER INSTEAD: get_eliminate_status for deployment jobs and success rates; get_patch_status for TruRisk coverage/gaps; get_eliminate_coverage for mitigation availability.
+
+    Parameters:
+        platform: filter by platform — "Windows", "Linux", or "" for all.
+        severity: filter by vendor severity — "Critical", "Important", "Moderate", or "" for all.
+        security_only: if true, only return security patches (isSecurity=true).
+        reboot_only: if true, only return patches that require a reboot.
+        limit: max patches to return (default 30).
+
+    Returns: patches (list with title, platform, missingCount, installedCount, vendorSeverity, isSecurity, rebootRequired, category, cves, kb), total, bySeverity, byPlatform, securityPatches, nonSecurityPatches, rebootRequired count, summary.
+
+    Performance: ~3s cold / ~2s warm (parallel per-platform queries)."""
+    return outstanding_patches(platform=platform, severity=severity, security_only=security_only, reboot_only=reboot_only, limit=limit, detail=detail)
 
 
 @mcp.tool()


### PR DESCRIPTION
Addresses issue #190

- Adds outstanding patches support via /pm/v1/patches endpoint
- Returns top patches by missingCount with security/reboot grouping
- Platform and severity filtering support
- Updated docstrings for better routing