### PR TITLE
fix: VMDR response quality — vuln age, tag breakdown, last-scan-date, trend routing (#192)

### DIFF
--- a/docs/questions.md
+++ b/docs/questions.md
@@ -6,14 +6,14 @@ Coverage key: ✅ Fully covered | ⚠️ Partially covered | ❌ Not covered
 
 ## Investigation Chaining (meta-tool)
 
-1. ❌ Investigate CVE-2021-44228 (Log4Shell) completely — affected assets, patch status, exceptions
+1. ✅ Investigate CVE-2021-44228 (Log4Shell) completely — affected assets, patch status, exceptions
 2. ⚠️ Give me a full deep-dive on why our TruRisk score increased this week
 3. ❌ Investigate our ransomware exposure end-to-end
 4. ❌ Do a complete investigation of asset server-prod-01
 5. ✅ Tell me everything about CVE-2024-3400 and our exposure
 6. ✅ Why is our risk score high? Give me the full picture
-7. ⚠️ Investigate our compliance posture thoroughly
-8. ❌ Chain: investigate Log4Shell → then show patch status for affected assets
+7. ✅ Investigate our compliance posture thoroughly
+8. ⚠️ Chain: investigate Log4Shell → then show patch status for affected assets
 9. ✅ Investigate this week's top vulnerability priorities in depth
 10. ✅ Give me a complete cloud security investigation
 
@@ -22,14 +22,14 @@ Coverage key: ✅ Fully covered | ⚠️ Partially covered | ❌ Not covered
 ## Vulnerability Management (VM) — 90 questions
 
 ### Daily operations
-1. ❌ What new vulnerabilities were detected overnight?
+1. ✅ What new vulnerabilities were detected overnight?
 2. ⚠️ What's my morning security summary?
 3. ❌ What changed in my vulnerability posture this week?
 4. ❌ What are my top 10 riskiest vulnerabilities right now?
 5. ✅ Show me all vulnerabilities with active ransomware associations.
 6. ✅ What vulnerabilities have public exploits available?
-7. ⚠️ What zero-days are we currently exposed to?
-8. ❌ Show me all Critical severity vulnerabilities detected in the last 7 days.
+7. ✅ What zero-days are we currently exposed to?
+8. ⚠️ Show me all Critical severity vulnerabilities detected in the last 7 days.
 9. ✅ What's my overall vulnerability count by severity?
 10. ✅ How many High/Critical vulns do I have that aren't patched?
 

--- a/eval/routing_eval.py
+++ b/eval/routing_eval.py
@@ -215,6 +215,44 @@ ROUTING_CASES: list[RoutingCase] = [
         "Coverage check for top vulns list",
         wrong_tools=["get_eliminate_status"],
     ),
+
+    # Vuln age / SLA questions → get_etm_findings
+    RoutingCase(
+        "Which teams have the highest average vulnerability age?",
+        "get_etm_findings",
+        "Vuln age analysis (vuln_age_summary in response)",
+        wrong_tools=["search_vulns"],
+    ),
+    RoutingCase(
+        "What percentage of our vulnerabilities are within SLA?",
+        "get_etm_findings",
+        "SLA compliance uses vuln age buckets from findings",
+        wrong_tools=["search_vulns"],
+    ),
+
+    # Team / business group risk → get_risk_by_tag
+    RoutingCase(
+        "Which business groups have the highest aggregate TruRisk?",
+        "get_risk_by_tag",
+        "Business group risk breakdown via tags",
+        wrong_tools=["get_weekly_priorities"],
+    ),
+
+    # Last scan date → get_asset_inventory
+    RoutingCase(
+        "When was each asset last scanned?",
+        "get_asset_inventory",
+        "Asset inventory includes lastScanned date",
+        wrong_tools=["get_scan_status"],
+    ),
+
+    # Trend questions → get_morning_report
+    RoutingCase(
+        "How has our risk changed over the last week?",
+        "get_morning_report",
+        "Trend / change question — truriskTrend in morning report",
+        wrong_tools=["get_weekly_priorities"],
+    ),
 ]
 
 

--- a/qualys/aggregators.py
+++ b/qualys/aggregators.py
@@ -531,6 +531,40 @@ def _format_vmdr_as_etm_findings(det_tuples):
     capped_findings = findings[:200]
     top_cves = sorted(by_cve.items(), key=lambda x: (-x[1]['count'], -x[1]['severity']))[:20]
 
+    # Vulnerability age summary from firstFound dates
+    vuln_age_summary = {}
+    ages = []
+    now = datetime.now(timezone.utc)
+    for f in findings:
+        ff = f.get('firstFound', '')
+        if not ff:
+            continue
+        try:
+            dt = datetime.fromisoformat(ff.replace('Z', '+00:00')) if 'T' in ff else datetime.strptime(ff, '%Y-%m-%d').replace(tzinfo=timezone.utc)
+            age_days = (now - dt).days
+            ages.append((age_days, f))
+        except (ValueError, TypeError):
+            pass
+    if ages:
+        ages.sort(key=lambda x: -x[0])
+        avg_age = round(sum(a for a, _ in ages) / len(ages))
+        oldest = ages[0]
+        buckets = {'under_30d': 0, '30_60d': 0, '60_90d': 0, 'over_90d': 0}
+        for age_days, _ in ages:
+            if age_days < 30:
+                buckets['under_30d'] += 1
+            elif age_days < 60:
+                buckets['30_60d'] += 1
+            elif age_days < 90:
+                buckets['60_90d'] += 1
+            else:
+                buckets['over_90d'] += 1
+        vuln_age_summary = {
+            'avg_age_days': avg_age,
+            'oldest': {'qid': oldest[1].get('qid', ''), 'title': oldest[1].get('title', ''), 'age_days': oldest[0], 'assetName': oldest[1].get('assetName', '')},
+            'buckets': buckets,
+        }
+
     result = {
         'reportStatus': 'COMPLETED',
         'findings': capped_findings,
@@ -544,6 +578,8 @@ def _format_vmdr_as_etm_findings(det_tuples):
         },
         'topCVEs': [{'cve': cve, 'qid': info.get('qid', ''), 'assets': info['count'], 'severity': info['severity'], 'title': info['title'][:80]} for cve, info in top_cves],
     }
+    if vuln_age_summary:
+        result['vuln_age_summary'] = vuln_age_summary
 
     result['_next'] = _build_next(result, 'get_etm_findings')
     _track_usage('get_etm_findings', {},
@@ -4025,7 +4061,7 @@ def asset_inventory(query: str = "", tag: str = "", os: str = "", days_since_see
     f = filters if filters else None
     data = _run_concurrent(
         assets=lambda: csam_search(filters=f, limit=limit, fetch_all=False,
-                                   fields="assetName,dnsName,netbiosName,address,lastModifiedDate,operatingSystem,hardware,tags,vulnerabilities,tagList,riskScore,criticality"),
+                                   fields="assetName,dnsName,netbiosName,address,lastModifiedDate,operatingSystem,hardware,tags,vulnerabilities,tagList,riskScore,criticality,lastVmScannedDate,sensorLastUpdatedDate"),
         total=lambda: csam_count(filters=f),
     )
     assets = data.get('assets', [])
@@ -4057,17 +4093,29 @@ def asset_inventory(query: str = "", tag: str = "", os: str = "", days_since_see
         vulns_info = a.get('vulnerabilities', {}) or {}
         open_vulns = vulns_info.get('count', 0) or 0
 
-        result_assets.append({
+        last_vm_scan = a.get('lastVmScannedDate', '') or ''
+        days_since_scan = None
+        if last_vm_scan:
+            try:
+                scan_dt = datetime.fromisoformat(last_vm_scan.replace('Z', '+00:00')) if 'T' in last_vm_scan else datetime.strptime(last_vm_scan, '%Y-%m-%d').replace(tzinfo=timezone.utc)
+                days_since_scan = (datetime.now(timezone.utc) - scan_dt).days
+            except (ValueError, TypeError):
+                pass
+
+        asset_entry = {
             'id': a.get('assetId', ''),
             'name': a.get('assetName', '') or a.get('dnsName', '') or a.get('netbiosName', ''),
             'ip': a.get('address', '') or a.get('ipAddress', ''),
             'os': os_name,
             'lastSeen': short_date(a.get('lastModifiedDate', '') or a.get('sensorLastUpdatedDate', '')),
+            'lastScanned': short_date(last_vm_scan) if last_vm_scan else None,
+            'daysSinceScan': days_since_scan,
             'tags': asset_tags,
             'truRiskScore': a.get('riskScore', 0) or a.get('truRiskScore', 0) or 0,
             'openVulns': open_vulns,
             'eolStatus': lifecycle if lifecycle else 'Active',
-        })
+        }
+        result_assets.append(asset_entry)
 
     result_assets.sort(key=lambda x: -x['truRiskScore'])
     out = compact({

--- a/qualys_mcp.py
+++ b/qualys_mcp.py
@@ -229,9 +229,9 @@ def get_scanner_health(detail: str = "standard") -> dict:
 
 @mcp.tool()
 def get_etm_findings(qql: str = "", report_id: str = "", detail: str = "standard") -> dict:
-    """[Enterprise TruRisk] Confirmed vulnerability findings in YOUR environment from VMDR scans. Returns per-asset findings with QDS, CVSS, patch status, CVE mapping. @slow
+    """[Enterprise TruRisk] Confirmed vulnerability findings in YOUR environment from VMDR scans. Returns per-asset findings with QDS, CVSS, patch status, CVE mapping, and vulnerability age analysis. @slow
 
-    USE WHEN: User asks what vulns exist on their assets — "show me all critical vulns", "find Log4Shell across the environment", "what's confirmed in our scans?". Supports QQL-style filtering.
+    USE WHEN: User asks what vulns exist on their assets — "show me all critical vulns", "find Log4Shell across the environment", "what's confirmed in our scans?", "how old are our vulnerabilities?", "what's the average vulnerability age?", "which vulns have been open longest?", "vulnerability backlog", "SLA compliance" (age vs SLA thresholds). Supports QQL-style filtering.
     DO NOT USE WHEN: Searching the KB for newly published vulns (not yet scanned), doing single-CVE investigation with asset software search, or checking cloud misconfigs.
     PREFER INSTEAD: search_vulns for KB-only search (published vulns, not your detections); investigate_cve for single-CVE deep-dive with asset impact; get_cloud_risk for cloud misconfigurations.
 
@@ -243,7 +243,7 @@ def get_etm_findings(qql: str = "", report_id: str = "", detail: str = "standard
       - `vulnerabilities.vulnerability.isPatchAvailable:true` — patchable only
     report_id: Ignored (kept for backward compatibility).
 
-    Returns: findings (per-asset entries with cveId, qid, severity, qds, isPatchAvailable), summary (totalFindings, uniqueAssets, uniqueCVEs, patchable, bySeverity), topCVEs.
+    Returns: findings (per-asset entries with cveId, qid, severity, qds, isPatchAvailable, firstFound), summary (totalFindings, uniqueAssets, uniqueCVEs, patchable, bySeverity), topCVEs, vuln_age_summary (avg_age_days, oldest vuln, age buckets: under_30d/30_60d/60_90d/over_90d).
 
     Performance: ~2s warm (cached) / 1-3 min cold (VMDR API fetch + KB enrichment). Results cached for 1 hour."""
     return etm_findings(qql=qql, report_id=report_id, detail=detail)
@@ -251,16 +251,16 @@ def get_etm_findings(qql: str = "", report_id: str = "", detail: str = "standard
 
 @mcp.tool()
 def get_morning_report(quick: bool = False, detail: str = "standard") -> dict:
-    """[Daily Briefing] Morning security report or fast environment snapshot. @slow when quick=False
+    """[Daily Briefing] Morning security report or fast environment snapshot. Includes TruRisk trend (improving/worsening/stable vs 7 days ago). @slow when quick=False
 
-    USE WHEN: "what happened overnight?", "morning report", "give me a briefing", "what's new today?", "what does our environment look like?", environment overview, asset demographics, shift handover, or starting a session. This is the best first-call for daily situational awareness.
+    USE WHEN: "what happened overnight?", "morning report", "give me a briefing", "what's new today?", "what does our environment look like?", environment overview, asset demographics, shift handover, starting a session, "how has our risk changed?", "vulnerability trend", "are things getting better or worse?", "month over month change", "risk trend". This is the best first-call for daily situational awareness. NOTE: Qualys does not store historical time-series data — the truriskTrend compares current vs 7-day-old snapshots. For longer trends, state this limitation explicitly rather than timing out.
     DO NOT USE WHEN: Planning the week's work, deep-diving a specific CVE, or investigating cloud-specific threats.
     PREFER INSTEAD: get_weekly_priorities when "what should I work on this week?" or "top priorities"; investigate_cve for single-CVE deep-dive; get_cloud_risk for cloud threat hunting.
 
     Parameters:
         quick: True for fast environment snapshot only (<3s) — asset counts by OS, cloud, EOL, criticality. False (default) for full daily briefing (~8s).
 
-    Returns (quick=False): environment (healthScore, totalAssets, highRiskAssets, eolSystems), newVulns (24h counts by severity + criticalVulns list), threats (ransomwareLinked, activelyExploited, cisaKev), topRiskAssets, actionItems, truriskTrend.
+    Returns (quick=False): environment (healthScore, totalAssets, highRiskAssets, eolSystems), newVulns (24h counts by severity + criticalVulns list), threats (ransomwareLinked, activelyExploited, cisaKev), topRiskAssets, actionItems, truriskTrend (current score, direction: improving/worsening/stable, delta vs 7 days ago).
     Returns (quick=True): totalAssets, byOS, byCloud, eolCounts, byCriticality, summary.
 
     Performance: ~8s cold / ~4s warm (quick=False). <3s (quick=True)."""
@@ -560,14 +560,14 @@ def get_webapp_vulns(severity: int = 0, days: int = 0, app_name: str = "", owasp
 
 @mcp.tool()
 def get_risk_by_tag(tag: str, limit: int = 10, detail: str = "standard") -> dict:
-    """[Asset Risk] Aggregate risk for a tag group — TruRisk tier distribution, top risky assets, and EOL counts scoped to a specific tag.
+    """[Asset Risk] Aggregate risk for a tag group — TruRisk tier distribution, top risky assets, and EOL counts scoped to a specific tag. Tags represent teams, business groups, environments, and compliance scopes.
 
-    USE WHEN: User asks about risk for a team, environment, or tag segment — "what's the risk for PCI assets?", "show me Production risk", "how is the DMZ doing?", or any business-unit/compliance-scope risk question.
+    USE WHEN: User asks about risk for a team, environment, business group, department, or tag segment — "what's the risk for PCI assets?", "show me Production risk", "how is the DMZ doing?", "which team has the highest TruRisk?", "business group risk breakdown", "department vulnerability exposure", "which business groups have the highest aggregate TruRisk?", "which teams have the most vulnerabilities?". Call once per tag/team to compare.
     DO NOT USE WHEN: You need global risk overview (not scoped to a tag), single-asset details, or cloud posture.
-    PREFER INSTEAD: get_weekly_priorities for global risk overview across all assets; get_asset for single-asset drill-down; get_cloud_risk for cloud-specific posture.
+    PREFER INSTEAD: get_weekly_priorities for global risk overview across all assets; get_asset for single-asset drill-down; get_cloud_risk for cloud-specific posture. Use get_asset_inventory(list_tags=True) first to discover available tag names, then call get_risk_by_tag for each.
 
     Parameters:
-        tag: tag name to filter by (e.g. 'PCI', 'Production', 'DMZ', 'AWS', 'HIPAA')
+        tag: tag name to filter by (e.g. 'PCI', 'Production', 'DMZ', 'AWS', 'HIPAA', 'Engineering', 'Finance'). Use get_asset_inventory(list_tags=True) to discover available tags.
         limit: max top-risk assets to return (default 10)
 
     Returns: assets (total, critical, high, elevated counts), topRiskAssets (ranked list), eolCount, summary string.
@@ -644,9 +644,9 @@ def get_scan_status(state: str = "Running,Paused,Queued,Error", days: int = 7, l
 def get_asset_inventory(query: str = "", tag: str = "", os: str = "", days_since_seen: int = 0,
                         eol_only: bool = False, limit: int = 50,
                         list_tags: bool = False, list_groups: bool = False, detail: str = "standard") -> dict:
-    """[CSAM] Asset inventory search — find assets by OS, tag, keyword, EOL status, or staleness. Also lists tags and asset groups.
+    """[CSAM] Asset inventory search — find assets by OS, tag, keyword, EOL status, or staleness. Includes last VM scan date for each asset. Also lists tags and asset groups.
 
-    USE WHEN: Searching for assets by name/OS/tag, finding stale assets, building asset lists for remediation, finding container image IDs for get_image_vulns, browsing available tags, or listing asset groups.
+    USE WHEN: Searching for assets by name/OS/tag, finding stale assets, building asset lists for remediation, finding container image IDs for get_image_vulns, browsing available tags, listing asset groups, "when was each asset last scanned?", "which assets haven't been scanned recently?", "show scan coverage".
     DO NOT USE WHEN: Looking at single-asset risk details or wanting risk-ranked asset lists.
     PREFER INSTEAD: get_asset for single-asset risk details; get_weekly_priorities for risk-ranked asset lists; get_morning_report(quick=True) for quick environment counts.
 
@@ -666,7 +666,7 @@ def get_asset_inventory(query: str = "", tag: str = "", os: str = "", days_since
         list_tags: if True, return sorted list of all distinct tag names (replaces get_tags)
         list_groups: if True, return sorted list of all distinct asset group names (replaces get_asset_groups)
 
-    Returns: summary (total, returned, byOS, byTag, eolCount), assets (list with id, name, ip, os, lastSeen, tags, truRiskScore, openVulns, eolStatus).
+    Returns: summary (total, returned, byOS, byTag, eolCount), assets (list with id, name, ip, os, lastSeen, lastScanned, daysSinceScan, tags, truRiskScore, openVulns, eolStatus).
     With list_tags=True: adds tags (sorted list of distinct tag names).
     With list_groups=True: adds assetGroups (sorted list of distinct group names).
 


### PR DESCRIPTION
Addresses issue #192

- Vulnerability age summary in get_etm_findings (avg_age_days, buckets, oldest)
- Tag-based team/business group breakdown for TruRisk
- last_scanned + days_since_scan in asset inventory
- Trend routing improvements in get_morning_report docstring