### PR TITLE
fix(investigate): use full QID set + detection cache for confirmedAffected count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ discovery/
 *.yaml
 *.yml
 !.github/**/*.yml
+.worktrees/

--- a/qualys/aggregators.py
+++ b/qualys/aggregators.py
@@ -941,37 +941,36 @@ def investigate_cve_agg(cve: str, detail: str = "standard") -> dict:
                 result['summary']['assetsWithSoftware'] = best_count
 
     if qids:
-        primary_qid = qids[0]
         try:
-            import xml.etree.ElementTree as _ET
-            det_url = f"{BASE_URL}/api/2.0/fo/asset/host/vm/detection/?action=list&qids={primary_qid}&status=New,Active,Re-Opened&truncation_limit=20&show_results=0"
-            det_data = api_get(det_url, timeout=45)
-            if det_data:
-                det_root = _ET.fromstring(det_data)
-                det_hosts = det_root.findall('.//HOST')
-                affected_list = []
-                for dh in det_hosts[:10]:
-                    affected_list.append({
-                        'hostId': dh.findtext('ID', ''),
-                        'ip': dh.findtext('IP', ''),
-                        'hostname': dh.findtext('DNS', '') or dh.findtext('DNS_DATA/HOSTNAME', '') or '',
-                        'os': dh.findtext('OS', ''),
-                    })
-                if affected_list:
-                    result['affectedAssets'] = affected_list
-                    result['detectionCount'] = len(det_hosts)
-                    result['summary']['confirmedAffected'] = len(det_hosts)
-                    result['confirmedHosts'] = {
-                        'searchedBy': f'QID {primary_qid} detections',
-                        'hostCount': len(det_hosts),
-                        'hosts': [{
-                            'hostId': a['hostId'],
-                            'ip': a['ip'],
-                            'hostname': a['hostname'],
-                            'os': a['os'],
-                        } for a in affected_list[:10]],
-                        'note': f'{len(det_hosts)} hosts have confirmed detections for QID {primary_qid} ({cve}).',
+            qids_set = set(qids)
+            all_dets = get_detections(severity=3)
+            matched = [d for d in all_dets if d.get('qid') in qids_set]
+            # Deduplicate by host_id so we count unique hosts, not detection records
+            seen_hosts: dict = {}
+            for d in matched:
+                hid = str(d.get('host_id') or d.get('hostId') or '')
+                if hid and hid not in seen_hosts:
+                    seen_hosts[hid] = d
+            if seen_hosts:
+                affected_list = [
+                    {
+                        'hostId': hid,
+                        'ip': d.get('ip', ''),
+                        'hostname': d.get('dnsName', '') or d.get('hostname', '') or '',
+                        'os': d.get('os', ''),
                     }
+                    for hid, d in list(seen_hosts.items())[:10]
+                ]
+                host_count = len(seen_hosts)
+                result['affectedAssets'] = affected_list
+                result['detectionCount'] = host_count
+                result['summary']['confirmedAffected'] = host_count
+                result['confirmedHosts'] = {
+                    'searchedBy': f'all {len(qids)} QID(s) for {cve} via detection cache',
+                    'hostCount': host_count,
+                    'hosts': affected_list,
+                    'note': f'{host_count} unique hosts have confirmed detections for {cve} across {len(qids)} QID(s).',
+                }
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary

- `investigate_cve_agg()` was querying only the **primary QID** (`qids[0]`) with `truncation_limit=20`, leaving all remaining QIDs unqueried
- When that capped query returned nothing, it fell back to the CSAM OS-asset count (e.g. *all Linux hosts*), inflating `confirmedAffected` by 3–10×
- Fix: filter the warm `get_detections(severity=3)` cache across the **full QID set**, deduplicate by `host_id`, and surface the true unique-host count — no extra API calls

## Root cause (from issue)

```
CVE-2026-23204 → 46 QIDs mapped
Only QIDs[0] queried, truncation_limit=20 → 0 results
CSAM fallback → 1,701 Linux hosts (total OS pool)
Actual confirmed detections: 598
```

## Fix

```python
qids_set = set(qids)
all_dets = get_detections(severity=3)   # warm cache — no extra API call
matched = [d for d in all_dets if d.get('qid') in qids_set]
# deduplicate by host_id → true unique host count
```

## Test plan

- [ ] `investigate("CVE-XXXX-XXXXX")` → `confirmedAffected` matches count from Qualys console QQL `vulnerabilities.vulnerability.cveIds:CVE-XXXX-XXXXX`
- [ ] CVE with no detections in cache → `confirmedAffected` absent or 0 (no CSAM OS fallback inflating the number)
- [ ] `confirmedHosts.searchedBy` reflects all QIDs, not just the primary

Closes kering-security/cert-mcp-factory#59